### PR TITLE
Renormalize sampling boundary per-site; mean-per-class MNIST viz

### DIFF
--- a/analysis/visualize/mnist_samples.py
+++ b/analysis/visualize/mnist_samples.py
@@ -1,12 +1,14 @@
 """Visualize learned MNIST distribution by sampling from a trained ConditionalBornMachine.
 
-Samples a few images per digit class and displays one randomly-chosen
-sample per class in a 2×5 grid (digits 0–9).
+Samples n_per_class images per digit class and displays the per-class mean
+image in a 2×5 grid (digits 0–9). The mean acts as a sanity check: even when
+individual samples look noisy (low bond dim), the per-class mean should resemble
+a blurry class-average digit if the model and sampler are working.
 
 Usage
 -----
     python -m analysis.visualize.mnist_samples --run <run_dir>
-    python -m analysis.visualize.mnist_samples --run <run_dir> --num-bins 100 --binarize
+    python -m analysis.visualize.mnist_samples --run <run_dir> --num-bins 100
     python -m analysis.visualize.mnist_samples --run <run_dir> --save-dir <dir>
 """
 
@@ -35,8 +37,7 @@ logger = logging.getLogger(__name__)
 
 RUN_DIR = "outputs/test/0"
 NUM_BINS = 100
-N_PER_CLASS = 8
-BINARIZE = False
+N_PER_CLASS = 64
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
@@ -44,7 +45,6 @@ def sample_and_plot(
     run_dir: str,
     n_per_class: int = N_PER_CLASS,
     num_bins: int = NUM_BINS,
-    binarize: bool = BINARIZE,
     save_dir: str | None = None,
     device: str = DEVICE,
 ):
@@ -64,21 +64,18 @@ def sample_and_plot(
     num_classes = cbm.out_dim
     img_dim = math.isqrt(samples.shape[1])
 
+    lo, hi = cbm.input_range
     fig, axes = plt.subplots(2, 5, figsize=(10, 4))
     for c in range(min(num_classes, 10)):
         ax = axes[c // 5, c % 5]
-        class_samples = samples[labels == c]
-        idx = torch.randint(len(class_samples), (1,)).item()
-        img = class_samples[idx].float()
-        lo, hi = cbm.input_range
-        img = (img - lo) / (hi - lo)
-        if binarize:
-            img = (img > 0.5).float()
-        ax.imshow(img.reshape(img_dim, img_dim), cmap="gray", vmin=0, vmax=1)
+        class_samples = samples[labels == c].float()
+        class_samples = (class_samples - lo) / (hi - lo)   # rescale to [0, 1]
+        mean_img = class_samples.mean(dim=0)               # per-class mean
+        ax.imshow(mean_img.reshape(img_dim, img_dim), cmap="gray", vmin=0, vmax=1)
         ax.set_title(f"Digit {c}", fontsize=9)
         ax.axis("off")
 
-    fig.suptitle("Sampled MNIST digits (one per class)", fontsize=11)
+    fig.suptitle("Mean sampled MNIST digit per class", fontsize=11)
     plt.tight_layout()
 
     if save_dir is not None:
@@ -99,7 +96,6 @@ if __name__ == "__main__":
     parser.add_argument("--run", default=None, help="Path to Hydra run directory.")
     parser.add_argument("--num-bins", type=int, default=NUM_BINS)
     parser.add_argument("--n-per-class", type=int, default=N_PER_CLASS)
-    parser.add_argument("--binarize", action="store_true")
     parser.add_argument("--save-dir", default=None)
     parser.add_argument("--device", default=DEVICE)
     cli_args = parser.parse_args()
@@ -109,7 +105,6 @@ if __name__ == "__main__":
             run_dir=cli_args.run,
             n_per_class=cli_args.n_per_class,
             num_bins=cli_args.num_bins,
-            binarize=cli_args.binarize,
             save_dir=cli_args.save_dir,
             device=cli_args.device,
         )
@@ -118,5 +113,4 @@ if __name__ == "__main__":
             run_dir=RUN_DIR,
             n_per_class=N_PER_CLASS,
             num_bins=NUM_BINS,
-            binarize=BINARIZE,
         )

--- a/src/model.py
+++ b/src/model.py
@@ -552,6 +552,11 @@ class ConditionalBornMachine(tk.models.MPS):
         for start in range(0, n, batch_size):
             N = min(batch_size, n - start)
             H = left.unsqueeze(0).expand(N, -1).clone().to(dev)  # (N, D_left)
+            # Per-sample renormalization: sampling is invariant under per-row
+            # positive rescaling of H (multinomial normalizes each row), so we
+            # keep H at O(1) every site to avoid amplitude overflow/underflow on
+            # long chains (mirrors the per-node renorm in log_partition_function).
+            H = H / H.norm(dim=-1, keepdim=True).clamp_min(1e-30)
             self._h_node._direct_set_tensor(H)
             samples = torch.zeros(N, self._data_dim, device=dev)
             for k, T in enumerate(tensors):
@@ -561,8 +566,9 @@ class ConditionalBornMachine(tk.models.MPS):
                 p = (C * C.conj()).real.sum(-1).clamp(min=0)    # (N, bins)
                 idx = torch.multinomial(p + 1e-15, 1).squeeze(-1)
                 samples[:, k] = grid[idx]
-                self._h_node._direct_set_tensor(
-                    C[torch.arange(N, device=dev), idx, :])
+                H_next = C[torch.arange(N, device=dev), idx, :]  # (N, D_r)
+                H_next = H_next / H_next.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+                self._h_node._direct_set_tensor(H_next)
             chunks.append(samples.cpu())
         del cond_mps
         return torch.cat(chunks, dim=0)

--- a/tests/unit/test_cbm.py
+++ b/tests/unit/test_cbm.py
@@ -6,10 +6,11 @@ from unittest.mock import patch
 from src.model import CBMConfig, ConditionalBornMachine, MPSInitConfig
 
 
-def _tiny_cbm(embedding="fourier", dtype="float32", data_dim=2, num_classes=2):
+def _tiny_cbm(embedding="fourier", dtype="float32", data_dim=2, num_classes=2,
+              bond_dim=2, std=1e-3):
     cfg = CBMConfig(
         embedding=embedding,
-        init_kwargs=MPSInitConfig(in_dim=2, bond_dim=2, dtype=dtype, std=1e-3),
+        init_kwargs=MPSInitConfig(in_dim=2, bond_dim=bond_dim, dtype=dtype, std=std),
     )
     return ConditionalBornMachine(cfg=cfg, data_dim=data_dim, num_classes=num_classes)
 
@@ -181,6 +182,68 @@ def test_sample_complex_dtype():
     cbm = _tiny_cbm(dtype="complex64")
     s = cbm.sample(0, n=4, num_bins=10)
     assert s.is_floating_point()  # output always real
+
+
+# ── sampling numerical stability (per-site H renormalization) ─────────────────
+
+def _old_sample_loop(cbm, class_idx, n, num_bins):
+    """Pre-fix sampling loop: byte-for-byte ConditionalBornMachine.sample()
+    EXCEPT the two H-renormalization lines are removed. Uses the same node
+    contraction path so the only difference under test is the renormalization."""
+    cond = cbm._make_conditioned_net(class_idx)
+    dev = cbm._mats_env[0].tensor.device
+    grid = torch.linspace(*cbm.input_range, num_bins, device=dev)
+    Phi = cbm.embedding(grid).to(cbm.dtype)
+    left = cond._left_node.tensor
+    tensors = [node.tensor for node in cond._mats_env]
+    H = left.unsqueeze(0).expand(n, -1).clone().to(dev)
+    cbm._h_node._direct_set_tensor(H)
+    samples = torch.zeros(n, cbm._data_dim, device=dev)
+    for k, T in enumerate(tensors):
+        T_embs = torch.einsum('ijk,bj->ibk', T, Phi)
+        cbm._u_node._direct_set_tensor(T_embs)
+        C = (cbm._h_node @ cbm._u_node).tensor
+        p = (C * C.conj()).real.sum(-1).clamp(min=0)
+        idx = torch.multinomial(p + 1e-15, 1).squeeze(-1)
+        samples[:, k] = grid[idx]
+        cbm._h_node._direct_set_tensor(C[torch.arange(n, device=dev), idx, :])
+    return samples.cpu()
+
+
+def _argmax_multinomial(weights, num_samples, *args, **kwargs):
+    """Deterministic stand-in for torch.multinomial(·, 1): argmax is exactly
+    scale-invariant, so it exposes any change in sampling decisions."""
+    return weights.argmax(dim=-1, keepdim=True)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "complex64"])
+def test_sample_renorm_matches_old_method(dtype):
+    # On a short chain (no overflow) the renormalized sampler must reproduce the
+    # old method bit-for-bit: per-row positive rescaling of H leaves the draw
+    # unchanged. Patch multinomial -> argmax to remove RNG.
+    cbm = _tiny_cbm(dtype=dtype, data_dim=4, bond_dim=3, std=0.5)
+    with patch("torch.multinomial", _argmax_multinomial):
+        s_new = cbm.sample(0, n=16, num_bins=12)
+        s_old = _old_sample_loop(cbm, 0, 16, 12)
+    assert torch.equal(s_new, s_old)
+
+
+def test_sample_keeps_boundary_normalized_long_chain():
+    # MNIST-scale regime: a long chain. The fix keeps the running boundary H at
+    # unit norm every site, so output stays finite and non-degenerate.
+    cbm = _tiny_cbm(dtype="complex64", data_dim=250)
+    cbm.eval()
+    cbm.renormalize_(log_target=0.0)
+    with patch.object(cbm._h_node, "_direct_set_tensor",
+                      wraps=cbm._h_node._direct_set_tensor) as spy:
+        s = cbm.sample(0, n=8, num_bins=8)
+    assert torch.isfinite(s).all()
+    assert s.unique().numel() > 1  # not collapsed to a single value
+    # Every boundary set into the contraction node is per-sample unit-normalized.
+    assert spy.call_args_list, "H was never set"
+    for call in spy.call_args_list:
+        norms = call.args[0].norm(dim=-1)
+        assert torch.allclose(norms, torch.ones_like(norms), atol=1e-4)
 
 
 # ── sample_all_classes ──────────────────────────────────────────────────────


### PR DESCRIPTION
sample() now renormalizes the running boundary vector H to unit norm at every site. Sampling is invariant under per-row positive rescaling of H (multinomial normalizes each row), so this is exact (bit-identical draws to the old method) while keeping H/C/p at O(1) to avoid amplitude overflow/underflow on long chains — mirroring the per-node renorm already done in log_partition_function.

Tests:
- test_sample_renorm_matches_old_method: argmax-deterministic, asserts the renormalized sampler reproduces the pre-fix loop bit-for-bit (both dtypes).
- test_sample_keeps_boundary_normalized_long_chain: 250-site chain, asserts H stays unit-norm every site and output is finite + non-degenerate.
- _tiny_cbm gains bond_dim/std params for non-degenerate conditionals.

mnist_samples.py: display per-class mean of samples (the standard sanity-check view) instead of one random sample; n_per_class 8 -> 64; drop --binarize.