### PR TITLE
gibbs: attack-radius-agnostic purification + local candidate grid + a…

### DIFF
--- a/analysis/CSV_SCHEMA.md
+++ b/analysis/CSV_SCHEMA.md
@@ -107,6 +107,12 @@ false-positive rate in percent (the threshold `τ` is the `{q}`-th percentile of
 | `gibbs_purify_acc/{eps}/{n_sweeps}` | Accuracy after Gibbs-sampling purification. Only when `COMPUTE_GIBBS_PURIFICATION=True`. |
 | `gibbs_purify_recovery/{eps}/{n_sweeps}` | Recovery rate after Gibbs purification. |
 
+> The Gibbs columns are keyed by **`n_sweeps`, not a radius** — Gibbs purification is
+> attack-radius agnostic. `step_radius` is a *per-sweep* L∞ move (the window re-centres
+> every sweep, so the k-sweep envelope is `k × step_radius × range_size`), and strength is
+> set by the number of sweeps alone. For a dedicated, more thoroughly reported Gibbs run
+> see `gibbs_data.csv` below.
+
 **`uq_joint_*` family** (`uq_joint_adv_acc/{eps}`, `uq_joint_detection/…`,
 `uq_joint_det_err_{detected,passed}/…`, `uq_joint_purify_{acc,recovery}/…`) — the **same
 metrics measured under the joint / adaptive attack** (`COMPUTE_JOINT_ATTACK=True`): a PGD
@@ -117,6 +123,42 @@ detector**. These are *harder-attack* counterparts of the columns above, **not**
 ### Companion file: `evaluation_summary.txt`
 
 Human-readable table with mean ± std across seeds, Pareto-frontier runs, and acc-vs-eps band. Contains no data not derivable from `evaluation_data.csv`.
+
+---
+
+## `gibbs_data.csv` — written by `analysis/gibbs.py`
+
+Lands in the **same** `analysis/outputs/{rel}/` directory as `evaluation_data.csv`; the two
+coexist because the filenames differ. One row per run, same `{eps}` absolute-value convention
+as above. Gibbs is orders of magnitude more expensive than every other post-hoc metric, which
+is why it has its own script and its own file.
+
+| Column | Description |
+|--------|-------------|
+| `gibbs_clean_acc` | Clean accuracy on the evaluated subsample, no attack, no defense. |
+| `gibbs_adv_acc/{eps}` | Accuracy under PGD at `eps`, **no defense**. |
+| `gibbs_clean_purify_acc/{k}` | Accuracy after `k` Gibbs sweeps on **clean** inputs (cost of purifying something that did not need it). |
+| `gibbs_purify_acc/{eps}/{k}` | Accuracy after `k` Gibbs sweeps on `eps`-attacked inputs. **The headline defense number.** |
+| `gibbs_purify_recovery/{eps}/{k}` | Fraction of previously-misclassified adversarial examples corrected by `k` sweeps. |
+| `gibbs_clean_log_px_mean`, `gibbs_adv_log_px_mean/{eps}` | Mean `log p(x)` before purification. |
+| `gibbs_clean_log_px_mean/{k}`, `gibbs_purify_log_px_mean/{eps}/{k}` | Mean `log p(x)` after `k` sweeps — should rise toward the clean level. |
+| `gibbs_n_samples` | **Test samples actually evaluated.** Cost is linear in this; it is often a subsample, so never read a table as full-test-set without checking. |
+| `gibbs_n_eval_seed` | Seed for the subsample. Fixed across runs ⇒ every column is paired. |
+| `gibbs_step_radius`, `gibbs_num_bins` | Purifier settings used (provenance). |
+| `gibbs_runtime_s` | Wall-clock seconds for the run — use it to size larger sweeps. |
+
+**Reading the `k` columns:** `k` is a sweep count, not a radius. Because the restriction
+window re-centres each sweep, `k` sweeps reach up to `k × gibbs_step_radius × range_size`
+from the input, so the defense is parameterized without reference to the attacker's budget.
+Comparing `gibbs_purify_acc/{eps}/{k}` across `k` at fixed `eps` traces the
+purification-strength curve; comparing against `gibbs_clean_purify_acc/{k}` shows what that
+strength costs on clean data.
+
+### Companion file: `gibbs_summary.txt`
+
+Human-readable accuracy table (rows: no-defense + one per `k`; columns: `eps=0` and each
+`eps`), plus across-run std/stderr, recovery rates, and the resolved `N_EVAL` / `step_radius`
+/ `num_bins` in the header. Contains no data not derivable from `gibbs_data.csv`.
 
 ### Reconstructing aggregates
 
@@ -334,6 +376,7 @@ summary_df = pd.DataFrame(summary_rows)
 | CSV location | Script | Grouping key | Row = | Diff columns saved? |
 |---|---|---|---|---|
 | `{seed_sweep\|alpha_curve}/{type}/{emb}/{arch}/{ds}/evaluation_data.csv` | `sweep.py` | `config/tracking.seed` | one run | N/A |
+| `…/{same dir}/gibbs_data.csv` | `gibbs.py` | `run_name` | one run | N/A |
 | `seed_sweep/cls_reg/{regime}/{emb}/{arch}/{ds}/evaluation_data.csv` | `cls_reg_analysis.py` | `max_epoch` + `seed` | one (run, epoch) | No — recomputed from `max_epoch=0` rows |
 | `seed_sweep/comb/{emb}/{arch}/{ds}/evaluation_data.csv` | `dev_comb_analysis.py` | `cls_epoch` + `seed` | one run | No — recomputed as `gen/` − `cls/` |
 

--- a/analysis/GUIDE.md
+++ b/analysis/GUIDE.md
@@ -13,6 +13,7 @@ For the full CSV column schema, see [`analysis/CSV_SCHEMA.md`](CSV_SCHEMA.md).
 |--------|-------------|
 | `run.py` | Single-model deep analysis (acc, rob, MIA, UQ) — callable API |
 | `sweep.py` | Post-hoc evaluation of a full seed sweep; primary analysis tool |
+| `gibbs.py` | Gibbs-purification defense on a seed sweep — split out because it costs orders of magnitude more than everything in `sweep.py` |
 | `hpo.py` | Explore HPO results: parameter-metric correlations, surface plots |
 | `batch.py` | Batch-queue runner: processes all unanalyzed sweeps via `sweep.py` |
 
@@ -173,6 +174,64 @@ df = pd.read_csv("analysis/outputs/alpha_curve/gen/legendre/d10r6/circles_1404/e
 alpha_col = "config/trainer.generative.criterion.kwargs.alpha"
 df.groupby(alpha_col)["eval/test/acc"].agg(["mean", "std"])
 ```
+
+---
+
+## `gibbs.py` — Gibbs Purification Analysis
+
+Separate from `sweep.py` because Gibbs purification dominates the cost of everything else
+combined: every candidate value of every feature is a full chain contraction, so cost is
+`N × data_dim × num_bins × max(n_sweeps)` per attack strength, per run.
+
+### Running it
+
+```bash
+# Defaults: PGD at 0.05/0.10/0.15 of the range, Gibbs for k = 1, 3, 6 sweeps
+python analysis/gibbs.py outputs/moons/nat/legendre/d10r6/seed_sweep_a1_2707
+
+# Cheap smoke run
+python analysis/gibbs.py <sweep_dir> --n-eval 100 --sweeps 1,3 --limit-runs 1
+
+# Full test split (expensive)
+python analysis/gibbs.py <sweep_dir> --n-eval all
+```
+
+### `--n-eval` is the cost knob
+
+Cost is **linear** in the number of test samples evaluated, so `--n-eval` is the first thing
+to reach for. The same fixed, seeded subsample is reused for the clean row and every epsilon,
+and across every run in the sweep — so all comparisons are paired even though the set is a
+subsample. Binomial sampling error on a reported accuracy is about `0.5/√N_EVAL`:
+
+| `--n-eval` | error |
+|---|---|
+| 100 | ~±5% |
+| 1000 (default) | ~±1.6% |
+| 4000 | ~±0.8% |
+
+The resolved count is printed up front with a projected contraction count, written to every
+CSV row as `gibbs_n_samples`, and echoed in the summary header — a subsampled table can never
+be silently misread as a full-test-set one.
+
+Other overrides: `--sweeps`, `--step-radius`, `--num-bins`, `--batch-size`, `--strengths`
+(fractions), `--device`, `--limit-runs`, `--n-eval-seed`.
+
+### Attack-radius agnostic — read the `k`, not a radius
+
+`step_radius` (default 0.05 of the feature domain) is a **per-sweep** L∞ move, not a global
+budget: the restriction window re-centres at the start of every sweep, so after `k` sweeps a
+coordinate can have travelled up to `k × step_radius × range_size`. Purification strength is
+therefore controlled by `--sweeps` alone, and the defense never has to be told the attacker's
+epsilon. Keep `step_radius` small and vary `k`.
+
+### Output files
+
+Written to the same `analysis/outputs/<sweep_path>/` directory as `sweep.py`'s output:
+
+| File | Description |
+|------|-------------|
+| `gibbs_data.csv` | One row per run. Schema in `CSV_SCHEMA.md`. |
+| `gibbs_summary.txt` | Accuracy table (no-defense + one row per `k` × one column per eps), across-run std/stderr, recovery rates, runtime |
 
 ---
 

--- a/analysis/gibbs.py
+++ b/analysis/gibbs.py
@@ -1,0 +1,529 @@
+# %% [markdown]
+# # Gibbs Purification Sweep Analysis
+#
+# Standalone counterpart to `analysis/sweep.py`, split out because Gibbs purification
+# is orders of magnitude more expensive than every other post-hoc metric and is worth
+# running (and re-running) on its own schedule.
+#
+# **What it does:** for each run in a seed sweep, generate PGD adversarial examples at
+# the same attack strengths `sweep.py` uses, then purify them with class-marginalized
+# Gibbs sampling for 1, 3 and 6 sweeps and measure accuracy recovery.
+#
+# **Attack-radius agnostic.** The Gibbs step radius is a *per-sweep* L∞ move
+# (default 0.05 of the feature domain), not a global perturbation ball: the window
+# re-centres at the start of every sweep, so after k sweeps a coordinate can have
+# travelled up to k × step_radius × (hi − lo). Purification strength is set by the
+# number of sweeps alone, so the defense never has to be told the attacker's budget.
+# Each result column therefore reports a k, not a radius.
+#
+# **Outputs** (mirrors `sweep.py`'s path convention, distinct filenames so both can
+# coexist in the same directory):
+#   analysis/outputs/{rel}/gibbs_data.csv      one row per run
+#   analysis/outputs/{rel}/gibbs_summary.txt   mean ± std table
+#
+# CLI usage:
+#     python analysis/gibbs.py <sweep_dir> [--n-eval N] [--sweeps 1,3,6] ...
+
+# %%
+import sys
+import argparse
+import logging
+import time
+from pathlib import Path
+
+if "__file__" in dir():
+    project_root = Path(__file__).parent.parent
+else:
+    project_root = Path.cwd().parent
+    if not (project_root / "src").exists():
+        project_root = Path.cwd()
+
+sys.path.insert(0, str(project_root))
+
+import numpy as np
+import pandas as pd
+import torch
+
+from src.utils.paths import data_root as _data_root
+from analysis.utils.resolve import (
+    resolve_embedding_from_path as _resolve_embedding,
+    resolve_regime_from_path as _resolve_regime_from_path,
+    embedding_range_size as _embedding_range_size,
+)
+
+logger = logging.getLogger(__name__)
+
+# %%
+# =============================================================================
+# CONFIGURATION - EDIT THIS SECTION
+# =============================================================================
+
+SWEEP_DIR = "outputs/moons/nat/legendre/d10r6/seed_sweep_a1_2707"
+
+# --- COST CONTROL: how many test samples Gibbs is evaluated on ---------------
+# Gibbs is essentially all of this script's cost and scales *linearly* in this
+# number, so it is the primary knob. The same fixed subsample is reused for the
+# clean row and every epsilon, and is seeded so it is identical across model
+# seeds and alphas — every comparison in the output table is therefore paired.
+# Sampling error on a reported mean accuracy is about 0.5/sqrt(N_EVAL):
+#   N_EVAL=100 -> ~±5%,  N_EVAL=1000 -> ~±1.6%,  N_EVAL=4000 -> ~±0.8%.
+# None (or --n-eval all) = use the full test split.
+N_EVAL = 1000
+N_EVAL_SEED = 0
+# -----------------------------------------------------------------------------
+
+# --- ATTACK CONFIG (kept in step with analysis/sweep.py) ---------------------
+# Fractions of the embedding range size; converted to absolute below.
+_STRENGTH_FRACTIONS = [0.05, 0.1, 0.15]
+ATTACK = {
+    "method": "PGD",
+    "norm": "inf",
+    "num_steps": 40,
+}
+
+# --- GIBBS CONFIG ------------------------------------------------------------
+GIBBS = {
+    # Purification strength knob. Cost is linear in max(n_sweeps).
+    "n_sweeps": [1, 3, 6],
+    # Candidate values per feature. With a step_radius these all land *inside*
+    # the window, so this is the resolution of the window, not of the domain.
+    "num_bins": 96,
+    # Candidate-expansion peak ∝ gibbs_batch_size × num_bins. On a 24 GB GPU, 24
+    # is safe for resized MNIST (r12) at num_bins=96; drop to ~8 for full-res.
+    "gibbs_batch_size": 24,
+    # Per-sweep L∞ step as a fraction of the feature domain. Deliberately small:
+    # strength comes from n_sweeps, not from this.
+    "step_radius": 0.05,
+}
+
+# Chunk size for the non-Gibbs forwards (class probs, log p(x), attack generation).
+EVAL_BATCH_SIZE = 256
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+# %%
+# --- CLI overrides -----------------------------------------------------------
+_cli = argparse.ArgumentParser(
+    add_help=True,
+    description="Gibbs-purification analysis for a seed sweep (see module docstring).",
+)
+_cli.add_argument("sweep_dir", nargs="?", default=None)
+_cli.add_argument(
+    "--n-eval", default=None,
+    help="Test samples to evaluate Gibbs on — THE cost knob (cost is linear in it). "
+         f"'all' or 0 = full test split. Default: {N_EVAL}.",
+)
+_cli.add_argument("--n-eval-seed", type=int, default=None,
+                  help="Seed for the evaluation subsample. Keep fixed across runs "
+                       "you intend to compare.")
+_cli.add_argument("--sweeps", default=None,
+                  help="Comma-separated Gibbs sweep counts, e.g. '1,3,6'.")
+_cli.add_argument("--step-radius", type=float, default=None,
+                  help="Per-sweep L-inf step as a fraction of the feature domain.")
+_cli.add_argument("--num-bins", type=int, default=None,
+                  help="Candidate values evaluated per feature.")
+_cli.add_argument("--batch-size", type=int, default=None,
+                  help="Gibbs batch size (memory: batch-size x num-bins per forward).")
+_cli.add_argument("--strengths", default=None,
+                  help="Comma-separated attack strengths as FRACTIONS of the "
+                       "embedding range, e.g. '0.05,0.1,0.15'.")
+_cli.add_argument("--device", default=None)
+_cli.add_argument("--limit-runs", type=int, default=None,
+                  help="Only evaluate the first N runs in the sweep directory.")
+_cli_args, _ = _cli.parse_known_args()
+
+if _cli_args.sweep_dir is not None:
+    SWEEP_DIR = _cli_args.sweep_dir
+if _cli_args.n_eval is not None:
+    _raw = str(_cli_args.n_eval).strip().lower()
+    N_EVAL = None if _raw in ("all", "0", "none", "") else int(_raw)
+if _cli_args.n_eval_seed is not None:
+    N_EVAL_SEED = _cli_args.n_eval_seed
+if _cli_args.sweeps is not None:
+    GIBBS["n_sweeps"] = [int(s) for s in _cli_args.sweeps.split(",") if s.strip()]
+if _cli_args.step_radius is not None:
+    GIBBS["step_radius"] = _cli_args.step_radius
+if _cli_args.num_bins is not None:
+    GIBBS["num_bins"] = _cli_args.num_bins
+if _cli_args.batch_size is not None:
+    GIBBS["gibbs_batch_size"] = _cli_args.batch_size
+if _cli_args.strengths is not None:
+    _STRENGTH_FRACTIONS = [float(s) for s in _cli_args.strengths.split(",") if s.strip()]
+if _cli_args.device is not None:
+    DEVICE = _cli_args.device
+
+# %%
+# --- Resolve embedding / regime from the sweep path --------------------------
+REGIME = _resolve_regime_from_path(SWEEP_DIR)
+if REGIME is None:
+    print(f"WARNING: Could not auto-detect training regime from '{SWEEP_DIR}'.")
+    REGIME = "unknown"
+
+_EMBEDDING = _resolve_embedding(SWEEP_DIR)
+if _EMBEDDING is None:
+    print(f"WARNING: Could not detect embedding from '{SWEEP_DIR}'. "
+          "Assuming Fourier (range size 1.0).")
+_RANGE_SIZE = _embedding_range_size(_EMBEDDING)
+
+# Attack strengths are ABSOLUTE from here on (fraction x range size), matching
+# the convention in analysis/run.py and analysis/sweep.py.
+ATTACK["strengths"] = [s * _RANGE_SIZE for s in _STRENGTH_FRACTIONS]
+
+SWEEP_POINTS = sorted({int(s) for s in GIBBS["n_sweeps"]})
+
+print("=" * 68)
+print(f"Gibbs purification analysis: {SWEEP_DIR}")
+print("=" * 68)
+print(f"Regime: {REGIME}  |  Embedding: {_EMBEDDING or 'unknown'} "
+      f"(range size {_RANGE_SIZE})  |  Device: {DEVICE}")
+print(f"Attack: {ATTACK['method']} L{ATTACK['norm']} steps={ATTACK['num_steps']}  "
+      f"strengths={[round(s, 6) for s in ATTACK['strengths']]} "
+      f"(fractions {_STRENGTH_FRACTIONS})")
+print(f"Gibbs:  sweeps={SWEEP_POINTS}  step_radius={GIBBS['step_radius']} "
+      f"num_bins={GIBBS['num_bins']}  batch={GIBBS['gibbs_batch_size']}")
+print(f"N_EVAL: {N_EVAL if N_EVAL is not None else 'full test split'} "
+      f"(seed {N_EVAL_SEED})")
+
+# %% [markdown]
+# ## Per-run evaluation
+
+# %%
+from analysis.utils.mia_utils import load_run_config, find_model_checkpoint
+from src.analysis.uq import _batched_forward, _recover_after_failure
+
+
+def _subsample_indices(n: int, n_eval, seed: int):
+    """Fixed random subsample of `range(n)`, or None to use everything.
+
+    Seeded independently of any model/data seed so the SAME test samples are drawn
+    for every run in the sweep and for every attack strength within a run — which
+    is what makes the clean/adv/purified columns paired rather than independent.
+    """
+    if n_eval is None or n_eval >= n:
+        return None
+    rng = np.random.default_rng(seed)
+    return torch.from_numpy(np.sort(rng.permutation(n)[:n_eval]))
+
+
+def _accuracy(born, x, labels, device):
+    preds = _batched_forward(born.class_probabilities, x, EVAL_BATCH_SIZE, device).argmax(dim=1)
+    return preds == labels
+
+
+def _mean_log_px(born, x, device):
+    return float(_batched_forward(born.marginal_log_probability, x, EVAL_BATCH_SIZE, device).mean())
+
+
+def _generate_adversarial(attack, born, x, labels, eps, device):
+    """Batched PGD generation over an already-subsampled tensor."""
+    out = []
+    for i in range(0, len(x), EVAL_BATCH_SIZE):
+        xb = x[i:i + EVAL_BATCH_SIZE].to(device)
+        yb = labels[i:i + EVAL_BATCH_SIZE].to(device)
+        out.append(attack.generate(born, xb, yb, eps, device).detach().cpu())
+    return torch.cat(out)
+
+
+def gibbs_analyze_run(run_dir: Path) -> dict:
+    """Load one run's model and measure Gibbs purification on clean + adversarial data.
+
+    Returns a flat dict of metrics. Column names reuse the conventions already
+    emitted by analysis/run.py (`gibbs_purify_acc/{eps}/{k}` etc.) so downstream
+    readers need no special-casing; separation from sweep.py is by filename.
+    """
+    from src.model import ConditionalBornMachine
+    from src.datahandler import DataHandler
+    from src.utils.evasion import RobustnessEvaluation
+    from src.utils.train import CriterionConfig
+    from src.analysis.purification import GibbsPurification
+    from omegaconf import OmegaConf
+
+    device = torch.device(DEVICE)
+    results: dict = {}
+
+    # 1. Model — mirrors analysis/run.py: accumulate=True forces the overflow-safe
+    #    amplitude path regardless of what the checkpoint's config says.
+    run_cfg = load_run_config(run_dir)
+    cbm = ConditionalBornMachine.load(str(find_model_checkpoint(run_dir)), accumulate=True)
+    cbm.to(device)
+    cbm.eval()
+
+    # 2. Data
+    OmegaConf.update(run_cfg, "dataset.overwrite", True, force_add=True)
+    datahandler = DataHandler(run_cfg.dataset)
+    datahandler.load()
+    datahandler.split_and_rescale(cbm)
+    datahandler.get_classification_loaders()
+    loader = datahandler.classification["test"]
+
+    x_test = torch.cat([b for b, _ in loader])
+    y_test = torch.cat([lb for _, lb in loader])
+
+    # 3. Subsample ONCE, before the attack loop, so PGD generation is charged on
+    #    N_EVAL samples too rather than on the whole split.
+    idx = _subsample_indices(len(x_test), N_EVAL, N_EVAL_SEED)
+    if idx is not None:
+        x_test, y_test = x_test[idx], y_test[idx]
+
+    results["gibbs_n_samples"] = len(x_test)
+    results["gibbs_n_eval_seed"] = N_EVAL_SEED
+    results["gibbs_step_radius"] = GIBBS["step_radius"]
+    results["gibbs_num_bins"] = GIBBS["num_bins"]
+
+    cbm.cache_log_Z()
+
+    purifier = GibbsPurification(
+        num_bins=GIBBS["num_bins"],
+        gibbs_batch_size=GIBBS["gibbs_batch_size"],
+        step_radius=GIBBS["step_radius"],
+    )
+
+    # 4. Clean reference: accuracy with no attack, before and after purification.
+    #    Establishes the cost of purifying something that did not need it.
+    try:
+        clean_correct = _accuracy(cbm, x_test, y_test, device)
+        results["gibbs_clean_acc"] = clean_correct.float().mean().item()
+        results["gibbs_clean_log_px_mean"] = _mean_log_px(cbm, x_test, device)
+
+        for k, (x_pur, log_px_after) in purifier.purify_snapshots(
+            cbm, x_test, SWEEP_POINTS, device
+        ).items():
+            results[f"gibbs_clean_purify_acc/{k}"] = (
+                _accuracy(cbm, x_pur, y_test, device).float().mean().item()
+            )
+            results[f"gibbs_clean_log_px_mean/{k}"] = float(log_px_after.mean())
+    except Exception as e:
+        logger.warning(f"Clean Gibbs failed: {e}; skipping")
+        _recover_after_failure(cbm)
+
+    # 5. Per attack strength: attack, score undefended, purify, score again.
+    attack = RobustnessEvaluation(
+        method=ATTACK["method"],
+        norm=ATTACK["norm"],
+        criterion=CriterionConfig(name="nll", kwargs=None),
+        strengths=ATTACK["strengths"],
+        num_steps=ATTACK["num_steps"],
+        random_start=True,
+    )
+
+    for eps in ATTACK["strengths"]:
+        try:
+            x_adv = _generate_adversarial(attack, cbm, x_test, y_test, eps, device)
+            adv_correct = _accuracy(cbm, x_adv, y_test, device)
+            misclassified = ~adv_correct
+            results[f"gibbs_adv_acc/{eps}"] = adv_correct.float().mean().item()
+            results[f"gibbs_adv_log_px_mean/{eps}"] = _mean_log_px(cbm, x_adv, device)
+
+            snapshots = purifier.purify_snapshots(cbm, x_adv, SWEEP_POINTS, device)
+        except Exception as e:
+            logger.warning(f"Gibbs failed (eps={eps}): {e}; skipping")
+            _recover_after_failure(cbm)
+            continue
+
+        for k, (x_pur, log_px_after) in snapshots.items():
+            try:
+                correct_after = _accuracy(cbm, x_pur, y_test, device)
+                n_misclf = int(misclassified.sum())
+                results[f"gibbs_purify_acc/{eps}/{k}"] = correct_after.float().mean().item()
+                results[f"gibbs_purify_recovery/{eps}/{k}"] = (
+                    float((misclassified & correct_after).sum()) / n_misclf
+                    if n_misclf > 0 else 1.0
+                )
+                results[f"gibbs_purify_log_px_mean/{eps}/{k}"] = float(log_px_after.mean())
+            except Exception as e:
+                logger.warning(f"Gibbs scoring failed (eps={eps}, k={k}): {e}; skipping")
+                _recover_after_failure(cbm)
+
+    return results
+
+
+# %%
+sweep_path = _data_root() / SWEEP_DIR
+run_dirs = sorted(
+    [d for d in sweep_path.iterdir()
+     if d.is_dir() and (d / ".hydra" / "config.yaml").exists()],
+    key=lambda d: d.name,
+) if sweep_path.exists() else []
+
+if _cli_args.limit_runs is not None:
+    run_dirs = run_dirs[:_cli_args.limit_runs]
+
+if not run_dirs:
+    print(f"No valid run directories found in {sweep_path}")
+
+# %%
+# --- Projected cost, printed before any work starts --------------------------
+if run_dirs:
+    _n_cond = 1 + len(ATTACK["strengths"])         # clean + one per epsilon
+    _n_eff = N_EVAL if N_EVAL is not None else "N"
+    print()
+    print(f"Found {len(run_dirs)} runs.")
+    if N_EVAL is not None:
+        _per_cond = N_EVAL * GIBBS["num_bins"] * max(SWEEP_POINTS)
+        print(f"Projected cost: {_per_cond:,} x data_dim candidate contractions per "
+              f"condition, {_n_cond} conditions per run, {len(run_dirs)} runs.")
+        print(f"  (= N_EVAL {N_EVAL} x num_bins {GIBBS['num_bins']} x "
+              f"max_sweeps {max(SWEEP_POINTS)}; linear in N_EVAL — halve it to halve "
+              f"the runtime.)")
+    else:
+        print(f"Projected cost: full test split x {GIBBS['num_bins']} bins x "
+              f"{max(SWEEP_POINTS)} sweeps x data_dim, {_n_cond} conditions per run.")
+    print()
+
+# %%
+rows = []
+_t_start = time.time()
+for i, run_dir in enumerate(run_dirs):
+    print(f"  [{i + 1}/{len(run_dirs)}] {run_dir.name} ...", flush=True)
+    row = {"run_name": run_dir.name, "run_path": str(run_dir)}
+    _t0 = time.time()
+    try:
+        row.update(gibbs_analyze_run(run_dir))
+    except Exception as e:
+        print(f"    FAILED: {e}")
+        logger.warning(f"Run {run_dir.name} failed: {e}")
+    row["gibbs_runtime_s"] = time.time() - _t0
+    print(f"    done in {row['gibbs_runtime_s']:.1f}s")
+    rows.append(row)
+
+df = pd.DataFrame(rows)
+if not df.empty:
+    print(f"\nEvaluation complete: {len(df)} runs in {time.time() - _t_start:.1f}s total.")
+
+# %% [markdown]
+# ## Export
+
+# %%
+# Mirror the sweep path under analysis/outputs/ (same convention as sweep.py).
+_sp = Path(SWEEP_DIR)
+if _sp.is_absolute():
+    try:
+        _sp = _sp.relative_to(_data_root())
+    except ValueError:
+        pass
+try:
+    _rel = _sp.relative_to("outputs")
+except ValueError:
+    _rel = _sp
+output_dir = _data_root() / "analysis" / "outputs" / _rel
+sweep_name = str(_rel)
+
+if not df.empty:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Output directory: {output_dir}")
+
+# %%
+if not df.empty:
+    def _smean(col):
+        return df[col].dropna().mean() if col in df.columns and df[col].notna().any() else float("nan")
+
+    def _sstd(col):
+        return df[col].dropna().std() if col in df.columns and df[col].notna().any() else float("nan")
+
+    def _sstderr(col):
+        if col not in df.columns:
+            return float("nan")
+        v = df[col].dropna()
+        return v.std() / (len(v) ** 0.5) if len(v) > 1 else float("nan")
+
+    def _fmt(v, w=10):
+        if v is None or (isinstance(v, float) and np.isnan(v)):
+            return "—".rjust(w)
+        return f"{v:.4f}".rjust(w)
+
+    _eps_list = ATTACK["strengths"]
+    _cols = ["eps=0"] + [f"{e:.4g}" for e in _eps_list]
+
+    # Rows: undefended, then one per sweep count.
+    _table = [("No defense", [_smean("gibbs_clean_acc")]
+                             + [_smean(f"gibbs_adv_acc/{e}") for e in _eps_list])]
+    for k in SWEEP_POINTS:
+        _table.append((
+            f"Gibbs (k={k})",
+            [_smean(f"gibbs_clean_purify_acc/{k}")]
+            + [_smean(f"gibbs_purify_acc/{e}/{k}") for e in _eps_list],
+        ))
+
+    _label_w = max(len(r[0]) for r in _table) + 2
+    _col_w = 10
+
+    summary_path = output_dir / "gibbs_summary.txt"
+    with open(summary_path, "w") as f:
+        f.write("=" * 68 + "\n")
+        f.write(f"Gibbs Purification: {sweep_name}\n")
+        f.write("=" * 68 + "\n\n")
+        f.write(f"Regime: {REGIME}  |  Runs: {len(df)}  |  Device: {DEVICE}\n")
+        f.write(f"Embedding: {_EMBEDDING or 'unknown'}  (range size {_RANGE_SIZE})\n")
+        f.write(f"Attack: {ATTACK['method']} L{ATTACK['norm']} "
+                f"steps={ATTACK['num_steps']}  fractions={_STRENGTH_FRACTIONS}\n")
+        _n_used = df["gibbs_n_samples"].dropna()
+        f.write(f"N_EVAL: {int(_n_used.iloc[0]) if len(_n_used) else 'n/a'} test samples "
+                f"(seed {N_EVAL_SEED})"
+                f"{'' if N_EVAL is not None else '  [full test split]'}\n")
+        f.write(f"Gibbs: sweeps={SWEEP_POINTS}  step_radius={GIBBS['step_radius']} "
+                f"(per-sweep L-inf step, NOT a global budget: after k sweeps the\n")
+        f.write(f"       envelope is k x {GIBBS['step_radius']} x range)  "
+                f"num_bins={GIBBS['num_bins']}\n\n")
+
+        f.write("-" * 68 + "\n")
+        f.write("Accuracy vs Perturbation Strength (mean across runs)\n")
+        f.write("-" * 68 + "\n\n")
+        f.write(" " * _label_w + "".join(c.rjust(_col_w) for c in _cols) + "\n")
+        for _lbl, _vals in _table:
+            f.write(f"{_lbl:<{_label_w}}" + "".join(_fmt(v) for v in _vals) + "\n")
+        f.write("\n")
+
+        f.write("-" * 68 + "\n")
+        f.write("Across-run std / stderr (same layout)\n")
+        f.write("-" * 68 + "\n\n")
+        for _stat, _fn in (("std", _sstd), ("stderr", _sstderr)):
+            f.write(f"{_stat}:\n")
+            f.write(" " * _label_w + "".join(c.rjust(_col_w) for c in _cols) + "\n")
+            _rows_stat = [("No defense", [_fn("gibbs_clean_acc")]
+                                         + [_fn(f"gibbs_adv_acc/{e}") for e in _eps_list])]
+            for k in SWEEP_POINTS:
+                _rows_stat.append((
+                    f"Gibbs (k={k})",
+                    [_fn(f"gibbs_clean_purify_acc/{k}")]
+                    + [_fn(f"gibbs_purify_acc/{e}/{k}") for e in _eps_list],
+                ))
+            for _lbl, _vals in _rows_stat:
+                f.write(f"{_lbl:<{_label_w}}" + "".join(_fmt(v) for v in _vals) + "\n")
+            f.write("\n")
+        f.write("Note: the above is spread ACROSS RUNS. Within a single run, the\n")
+        f.write(f"binomial sampling error on each accuracy is about "
+                f"{0.5 / max(int(_n_used.iloc[0]) if len(_n_used) else 1, 1) ** 0.5:.4f} "
+                f"at this N_EVAL.\n\n")
+
+        f.write("-" * 68 + "\n")
+        f.write("Recovery rate (fraction of misclassified adv examples fixed)\n")
+        f.write("-" * 68 + "\n\n")
+        f.write(" " * _label_w + "".join(f"{e:.4g}".rjust(_col_w) for e in _eps_list) + "\n")
+        for k in SWEEP_POINTS:
+            f.write(f"{f'Gibbs (k={k})':<{_label_w}}"
+                    + "".join(_fmt(_smean(f"gibbs_purify_recovery/{e}/{k}")) for e in _eps_list)
+                    + "\n")
+        f.write("\n")
+
+        if "gibbs_runtime_s" in df.columns:
+            _rt = df["gibbs_runtime_s"].dropna()
+            if len(_rt):
+                f.write(f"Runtime: {_rt.mean():.1f}s per run (total {_rt.sum():.1f}s)\n")
+        f.write("=" * 68 + "\n")
+
+    print(f"\nExported summary to: {summary_path}")
+    with open(summary_path) as f:
+        print(f.read())
+
+# %%
+if not df.empty:
+    _export_cols = [c for c in df.columns if not c.startswith("_")]
+    df[_export_cols].to_csv(output_dir / "gibbs_data.csv", index=False)
+    print(f"Saved gibbs_data.csv ({len(df)} runs, {len(_export_cols)} columns)")
+
+# %%
+print("\n" + "=" * 68)
+print("Gibbs Purification Analysis Complete")
+print("=" * 68)
+
+# %%

--- a/analysis/sweep.py
+++ b/analysis/sweep.py
@@ -143,7 +143,9 @@ GIBBS_CONFIG = {
     # 24 is safe for resized MNIST (r12) at num_bins=96 (~1.5× the old 8×200 peak);
     # drop to ~8 for full-res mnist_full (784 sites).
     "gibbs_batch_size": 24,
-    "radius": 0.1,
+    # Per-sweep L∞ step (fraction of the input range), NOT a global budget: the
+    # window re-centres each sweep, so after k sweeps the envelope is k×this.
+    "step_radius": 0.1,
     # Gibbs is ~99% of analysis cost and only estimates a mean over the test set, so
     # run it on a fixed random subsample (cheap metrics keep the full set). ~±1.5%
     # stderr at 1000. None = full test set.
@@ -222,7 +224,7 @@ if COMPUTE_UQ and UQ_CONFIG is not None and EVASION_CONFIG:
         _full_uq_config["gibbs_n_sweeps"] = GIBBS_CONFIG["n_sweeps"]
         _full_uq_config["gibbs_num_bins"] = GIBBS_CONFIG["num_bins"]
         _full_uq_config["gibbs_batch_size"] = GIBBS_CONFIG["gibbs_batch_size"]
-        _full_uq_config["gibbs_radius"] = GIBBS_CONFIG.get("radius")
+        _full_uq_config["gibbs_step_radius"] = GIBBS_CONFIG.get("step_radius")
         _full_uq_config["gibbs_subsample"] = GIBBS_CONFIG.get("subsample")
 elif COMPUTE_GIBBS_PURIFICATION and not COMPUTE_UQ:
     print("WARNING: COMPUTE_GIBBS_PURIFICATION=True requires COMPUTE_UQ=True; skipping Gibbs.")

--- a/analysis/utils/GUIDE.md
+++ b/analysis/utils/GUIDE.md
@@ -136,13 +136,25 @@ Note: gradient **descent** on NLL = ascent on log p(x). The final clamp ensures 
 
 **After purification, classify x* instead of x_adv.**
 
-> ✅ **Overflow-safe (was a known bug)**: the grid Gibbs sampler in `purification.py` now computes its per-bin weights in log space — `logsumexp(log_amp_sq(x_cand))` with the radius mask applied as `-inf`, sampled by `draw_from_grid_log`. Previously it used raw `abs_square(amplitudes(x_cand))` → `draw_from_grid`, which overflowed to `inf` on overflow-prone models; `draw_from_grid` mapped `posinf → 0`, silently zeroing the highest-probability bins so sampling ran *backwards*. Like the gradient-ascent path (which uses `marginal_log_probability`), it is now always overflow-safe.
+> ✅ **Overflow-safe (was a known bug)**: the grid Gibbs sampler in `purification.py` computes its per-bin weights in log space — `logsumexp(log_amp_sq(x_cand))`, sampled by `draw_from_grid_log`. Previously it used raw `abs_square(amplitudes(x_cand))` → `draw_from_grid`, which overflowed to `inf` on overflow-prone models; `draw_from_grid` mapped `posinf → 0`, silently zeroing the highest-probability bins so sampling ran *backwards*. Like the gradient-ascent path (which uses `marginal_log_probability`), it is now always overflow-safe.
+
+> 🔎 **Local candidate grid**: when a `step_radius` is set, the restricted sweep discretizes *each sample's own* window `[x̄_k ± δ] ∩ input_range` with all `num_bins` points, instead of masking a global `linspace(lo, hi, num_bins)` down to it. At δ = 0.05 the window is 10% of the domain, so the old scheme left ~10 admissible bins out of 96 and spent ~90% of every forward pass on candidates the mask then discarded. The local grid removes the mask entirely (no bin can be inadmissible, no row can be all `-inf`) and gives full resolution inside the window. Trade-off: the proposal support moves each sweep, so this is a local Metropolis-within-Gibbs-style move rather than exact Gibbs on one fixed discretization — `step_radius=None` remains the fixed-grid path.
 
 Reported metrics:
 - `eval/uq_purify_acc/<eps>/<r>` — accuracy on purified samples
 - `eval/uq_purify_recovery/<eps>/<r>` — fraction of originally misclassified samples that become correct after purification
 
 **Choosing r**: r should be ≥ ε (the attack radius) to have any chance of reversing the attack. In practice r ≈ ε works well; too large means purification can change the semantic content of the input.
+
+### Gibbs purification — no r to choose
+
+The Gibbs defense has no such knob, which is the point of it. `step_radius` is a *per-sweep*
+L∞ move (default 0.05 of the domain in `analysis/gibbs.py`), and the window re-centres at the
+start of every sweep, so after `k` sweeps a coordinate can have travelled up to
+`k × step_radius × range_size`. Strength is set by `n_sweeps` alone — no ε needs to be known
+or guessed. Reported as `gibbs_purify_acc/<eps>/<k>`, keyed by sweep count, not radius. Run it
+with `analysis/gibbs.py` (see `analysis/GUIDE.md`); `sweep.py` can also produce these columns
+via `COMPUTE_GIBBS_PURIFICATION`, but it is expensive enough to usually want its own run.
 
 ---
 

--- a/src/analysis/purification.py
+++ b/src/analysis/purification.py
@@ -176,27 +176,48 @@ class GibbsPurification:
     joint amplitudes over a discrete grid.  Multiple sweeps produce a sample
     more consistent with the model's learned distribution.
 
+    **Attack-radius agnostic.**  ``step_radius`` is a *per-sweep* L∞ step, not a
+    global perturbation budget: the restriction window is re-centred on the
+    sweep-start snapshot at the beginning of every sweep, so after ``k`` sweeps a
+    coordinate can have travelled up to ``k · step_radius · (hi - lo)`` from where
+    it started.  Purification strength is therefore controlled by ``n_sweeps``
+    alone, which means the defense never has to be told the attacker's budget.
+    Keep ``step_radius`` small (a local move) and vary ``n_sweeps``.
+
     Args:
-        num_bins: Resolution of the discrete grid over the input range.
+        num_bins: Number of candidate values evaluated per feature.  With a
+            ``step_radius`` these all fall *inside* the window (see below), so
+            this is the resolution of the window, not of the full input range.
         gibbs_batch_size: Number of adversarial samples processed per batch.
             Controls memory: gibbs_batch_size × num_bins inputs per forward pass.
             At bs=8, bins=200: 1600 forward evals per feature per sweep.
-        radius: Perturbation budget as a fraction of the input range size
-            (b - a).  Each sweep restricts resampling of feature i to
-            [x̄_i ± delta_abs] where delta_abs = radius * (hi - lo).
-            The same budget applies regardless of n_sweeps.  Intervals are
-            clamped to input_range.  If None, samples from the full input range.
+        step_radius: Per-sweep L∞ step as a fraction of the input range size
+            (hi - lo).  Feature i is resampled on a grid spanning
+            [x̄_i ± delta_abs] ∩ input_range, where delta_abs =
+            step_radius * (hi - lo) and x̄ is the sweep-start snapshot.
+            If None, samples from the full input range (unrestricted).
+
+    Note:
+        With a ``step_radius`` the candidate grid is built *locally*, per sample:
+        ``linspace(x̄_i - delta, x̄_i + delta, num_bins)`` clamped to the input
+        range.  This spends every candidate evaluation inside the window (a global
+        grid masked down to a 10%-wide window would discard ~90% of them) and gives
+        full ``num_bins`` resolution there.  The price is that the proposal support
+        moves each sweep, so this is a local Metropolis-within-Gibbs-style move
+        rather than exact Gibbs on one fixed discretization — the k→∞ limit is not
+        the model's discretized marginal.  That is the intended behaviour for a
+        local purification walk; ``step_radius=None`` is the fixed-grid path.
     """
 
     def __init__(
         self,
         num_bins: int,
         gibbs_batch_size: int = 8,
-        radius: Optional[float] = 0.1,
+        step_radius: Optional[float] = 0.1,
     ):
         self.num_bins = num_bins
         self.gibbs_batch_size = gibbs_batch_size
-        self.radius = radius
+        self.step_radius = step_radius
 
     def purify(
         self,
@@ -210,9 +231,10 @@ class GibbsPurification:
         Thin wrapper over :meth:`purify_snapshots` for the single-sweep-count case.
 
         Args:
-            born: ConditionalBornMachine instance (must be prepared and in eval mode).
+            born: ConditionalBornMachine instance.
             x_adv: Adversarial inputs, shape (n_samples, data_dim).
-            n_sweeps: Number of full sweeps over all features.
+            n_sweeps: Number of full sweeps over all features.  This, not
+                ``step_radius``, is the purification-strength knob.
             device: Torch device.
 
         Returns:
@@ -239,7 +261,7 @@ class GibbsPurification:
         the same RNG state.
 
         Args:
-            born: ConditionalBornMachine instance (must be prepared and in eval mode).
+            born: ConditionalBornMachine instance.
             x_adv: Adversarial inputs, shape (n_samples, data_dim).
             sweep_points: Sweep counts to snapshot (e.g. ``[1, 3, 5]``).
             device: Torch device.
@@ -257,11 +279,23 @@ class GibbsPurification:
         data_dim = x_adv.shape[1]
         lo, hi = born.input_range
 
-        input_space = torch.linspace(lo, hi, self.num_bins, device=device)
+        # Unrestricted path: one fixed grid over the whole input range, shared by
+        # every sample. Restricted path builds its grid per sample, per feature.
+        input_space = (
+            torch.linspace(lo, hi, self.num_bins, device=device)
+            if self.step_radius is None
+            else None
+        )
+        # Interpolation weights for the local windows, (num_bins,) in [0, 1].
+        unit_grid = (
+            torch.linspace(0.0, 1.0, self.num_bins, device=device)
+            if self.step_radius is not None
+            else None
+        )
 
-        # Convert relative radius to absolute.
+        # Convert the relative per-sweep step to an absolute one.
         delta_abs: Optional[float] = (
-            self.radius * (hi - lo) if self.radius is not None else None
+            self.step_radius * (hi - lo) if self.step_radius is not None else None
         )
 
         # Per-snapshot accumulation of purified batches (concatenated after the loop).
@@ -278,14 +312,15 @@ class GibbsPurification:
             bs = len(batch)
             x_cur = batch.clone()
 
-            # The candidate forward shape (bs*num_bins) is constant across all features
-            # and sweeps of this batch and never changes core roles, so a single reset
-            # here suffices — it re-traces only when bs changes (the final partial batch).
+            # Clear any data nodes left over from a previous batch. The candidate
+            # forward runs through the eager accumulate path (log_amp_sq), which
+            # resets around itself, so this is only hygiene between batches.
             born.reset()
 
             for s in range(1, max_sweeps + 1):
-                # Snapshot at sweep start; restriction intervals are centred on these
-                # values, not on within-sweep updated values.
+                # Snapshot at sweep start; the restriction window is centred on these
+                # values, not on within-sweep updated values. Re-centring each sweep is
+                # what makes the total budget k*delta rather than a single global ball.
                 x_bar = x_cur.clone() if delta_abs is not None else None
 
                 for k in tqdm(
@@ -295,6 +330,20 @@ class GibbsPurification:
                     leave=False,
                     dynamic_ncols=True,
                 ):
+                    # Candidate values for feature k. Unrestricted: the shared global
+                    # grid. Restricted: a per-sample grid spanning this sample's window
+                    # [x̄_k ± delta] ∩ [lo, hi], so every candidate is admissible by
+                    # construction and none of the num_bins resolution is wasted
+                    # outside the window.
+                    if delta_abs is None:
+                        grid_k = input_space                              # (bins,)
+                        flat_grid = input_space.repeat(bs)                # (bs*bins,)
+                    else:
+                        lo_k = (x_bar[:, k] - delta_abs).clamp(lo, hi)    # (bs,)
+                        hi_k = (x_bar[:, k] + delta_abs).clamp(lo, hi)    # (bs,)
+                        grid_k = lo_k[:, None] + (hi_k - lo_k)[:, None] * unit_grid[None, :]
+                        flat_grid = grid_k.reshape(-1)                    # (bs*bins,)
+
                     # Build (bs × num_bins) candidate inputs: x_cur with x[:, k] = grid.
                     x_cand = (
                         x_cur.unsqueeze(1)
@@ -302,7 +351,7 @@ class GibbsPurification:
                         .reshape(bs * self.num_bins, -1)
                         .clone()
                     )
-                    x_cand[:, k] = input_space.repeat(bs)
+                    x_cand[:, k] = flat_grid
 
                     with torch.no_grad():
                         # Sum |ψ(x,c)|² over classes → unnormalized p(x_i | x_{-i}),
@@ -314,15 +363,9 @@ class GibbsPurification:
                         las = born.log_amp_sq(x_cand)                      # (bs*bins, C)
                         log_p = torch.logsumexp(las, dim=-1).view(bs, self.num_bins)
 
-                    if delta_abs is not None:
-                        lo_k = (x_bar[:, k] - delta_abs).clamp(lo, hi).unsqueeze(1)
-                        hi_k = (x_bar[:, k] + delta_abs).clamp(lo, hi).unsqueeze(1)
-                        mask = (input_space[None, :] >= lo_k) & (input_space[None, :] <= hi_k)
-                        # Excluded bins are -inf (weight 0), the log-space
-                        # equivalent of the previous multiply-by-zero mask.
-                        log_p = log_p.masked_fill(~mask, float("-inf"))
-
-                    x_cur[:, k] = draw_from_grid_log(log_p, input_space)
+                    # No masking needed: the grid *is* the window, so every bin is
+                    # admissible and no row can be entirely -inf.
+                    x_cur[:, k] = draw_from_grid_log(log_p, grid_k)
 
                 if s in snap_results:
                     snap_results[s].append(x_cur.cpu().clone())
@@ -385,7 +428,7 @@ if __name__ == "__main__":
     assert log_px.isfinite().all(), "LikelihoodPurification: non-finite log_px"
     print(f"  LikelihoodPurification  shape={tuple(x_pur.shape)}  log_px_mean={log_px.mean().item():.4f}")
 
-    gibbs = GibbsPurification(num_bins=20, gibbs_batch_size=4, radius=0.1)
+    gibbs = GibbsPurification(num_bins=20, gibbs_batch_size=4, step_radius=0.1)
     x_g, log_px_g = gibbs.purify(cbm, x_adv, n_sweeps=1, device=device)
     assert x_g.shape == x_adv.shape, "GibbsPurification: shape mismatch"
     print(f"  GibbsPurification       shape={tuple(x_g.shape)}  log_px_mean={log_px_g.mean().item():.4f}")

--- a/src/analysis/uq.py
+++ b/src/analysis/uq.py
@@ -62,7 +62,10 @@ class UQConfig:
     gibbs_n_sweeps: List[int] = field(default_factory=lambda: [1, 3, 5])
     gibbs_num_bins: int = 200
     gibbs_batch_size: int = 8
-    gibbs_radius: Optional[float] = 0.1  # relative to input range; None = unrestricted
+    # Per-sweep L∞ step, as a fraction of the input range; None = unrestricted.
+    # NOT a global budget: the window re-centres each sweep, so after k sweeps the
+    # envelope is k*gibbs_step_radius*(hi-lo). Strength is set by gibbs_n_sweeps.
+    gibbs_step_radius: Optional[float] = 0.1
     # Gibbs is ~99% of UQ cost and reduces to a mean over the test set, so it runs on a
     # fixed random subsample (cheap metrics keep the full set). None = full set.
     gibbs_subsample: Optional[int] = None
@@ -583,7 +586,7 @@ class UQEvaluation:
             gibbs_purifier = GibbsPurification(
                 num_bins=cfg.gibbs_num_bins,
                 gibbs_batch_size=cfg.gibbs_batch_size,
-                radius=cfg.gibbs_radius,
+                step_radius=cfg.gibbs_step_radius,
             )
             sweep_points = sorted(set(cfg.gibbs_n_sweeps))
 

--- a/src/model.py
+++ b/src/model.py
@@ -54,7 +54,10 @@ def draw_from_grid_log(log_p: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
     log_p : torch.Tensor
         Unnormalized log weights, shape (batch, num_bins). ``-inf`` allowed.
     z : torch.Tensor
-        Grid of candidate values, shape (num_bins,).
+        Grid of candidate values. Either shape (num_bins,) — one grid shared by
+        every row — or (batch, num_bins), a per-row grid, so callers whose
+        candidate values differ per sample (e.g. a window centred on each
+        sample) can sample without a shared discretization.
 
     Returns
     -------
@@ -74,7 +77,9 @@ def draw_from_grid_log(log_p: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
     row_sums = p.sum(dim=-1, keepdim=True)
     p = torch.where(row_sums > 0, p, torch.ones_like(p))
     indices = torch.multinomial(p, num_samples=1).squeeze(1)
-    return z[indices]
+    if z.ndim == 1:
+        return z[indices]
+    return z.gather(1, indices.unsqueeze(1)).squeeze(1)
 
 
 @dataclass

--- a/tests/integration/test_gibbs_purification.py
+++ b/tests/integration/test_gibbs_purification.py
@@ -67,16 +67,18 @@ def test_purify_partial_batch(cbm):
     assert purified.shape == (n_samples, DATA_DIM)
 
 
-# --- Restricted Gibbs (radius) ---
+# --- Restricted Gibbs (step_radius) ---
+# step_radius is a PER-SWEEP L-inf step, not a global budget: the window re-centres
+# at the start of every sweep, so the k-sweep envelope is k*step_radius*(hi-lo).
 
 def test_restricted_purify_output_shape(cbm, x_adv):
-    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, radius=0.3)
+    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, step_radius=0.3)
     purified, _ = purifier.purify(cbm, x_adv, n_sweeps=1, device="cpu")
     assert purified.shape == (BATCH_SIZE, DATA_DIM)
 
 
 def test_restricted_purify_stays_in_input_range(cbm, x_adv):
-    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, radius=0.3)
+    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, step_radius=0.3)
     purified, _ = purifier.purify(cbm, x_adv, n_sweeps=1, device="cpu")
     lo, hi = cbm.input_range
     assert (purified >= lo - 1e-5).all()
@@ -84,24 +86,89 @@ def test_restricted_purify_stays_in_input_range(cbm, x_adv):
 
 
 def test_restricted_purify_stays_near_start(cbm):
-    # With a small radius, purified values must be within radius of x_adv
-    # (per feature, since each feature is sampled from [x_adv_k ± delta]).
+    # After ONE sweep the window is centred on x_adv, so every purified value must
+    # lie in [x_adv_k ± delta], and — since the candidate grid IS the window — must
+    # be one of the num_bins grid points of that window, not merely inside it.
     torch.manual_seed(0)
-    radius = 0.1
+    step_radius = 0.1
     x_adv = torch.full((BATCH_SIZE, DATA_DIM), 0.5)  # well inside input_range [0,1]
-    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, radius=radius)
+    purifier = GibbsPurification(
+        num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, step_radius=step_radius
+    )
     purified, _ = purifier.purify(cbm, x_adv, n_sweeps=1, device="cpu")
     lo, hi = cbm.input_range
-    delta = radius * (hi - lo)
-    # Each feature must stay within [x_adv_k - delta, x_adv_k + delta] ∩ [lo, hi]
+    delta = step_radius * (hi - lo)
+
     lo_bound = (x_adv - delta).clamp(lo, hi)
     hi_bound = (x_adv + delta).clamp(lo, hi)
     assert (purified >= lo_bound - 1e-5).all(), "Purified values below lower restriction bound"
     assert (purified <= hi_bound + 1e-5).all(), "Purified values above upper restriction bound"
 
+    # Every sample lands exactly on its own window's local grid.
+    expected = lo_bound.unsqueeze(-1) + (hi_bound - lo_bound).unsqueeze(-1) * torch.linspace(
+        0.0, 1.0, NUM_BINS
+    )
+    on_grid = (purified.unsqueeze(-1) - expected).abs().min(dim=-1).values
+    assert (on_grid < 1e-5).all(), "Purified value is not a point of its local window grid"
+
+
+def test_local_grid_uses_full_resolution_inside_window(cbm):
+    """The window is discretized with num_bins points, not sliced out of a global grid.
+
+    The old implementation masked a global linspace(lo, hi, num_bins) down to the
+    window, leaving only ~2*step_radius*num_bins admissible values and throwing the
+    rest of every forward pass away. With a local grid the window carries all
+    num_bins values, so the reachable set is strictly larger than the old one.
+    """
+    import math
+
+    torch.manual_seed(0)
+    step_radius = 0.1
+    num_bins = 40
+    x_adv = torch.full((64, DATA_DIM), 0.5)
+    purifier = GibbsPurification(
+        num_bins=num_bins, gibbs_batch_size=64, step_radius=step_radius
+    )
+    purified, _ = purifier.purify(cbm, x_adv, n_sweeps=1, device="cpu")
+
+    # Bins the old global-grid-plus-mask scheme could have offered inside the window.
+    old_admissible = math.ceil(2 * step_radius * num_bins) + 1
+    distinct = len(torch.unique(purified[:, 0]))
+    assert distinct > old_admissible, (
+        f"only {distinct} distinct values reachable, no better than the "
+        f"{old_admissible} a masked global grid would allow"
+    )
+
+
+def test_k_sweeps_widen_the_envelope(cbm):
+    """Purification strength comes from n_sweeps — this is the attack-agnostic property.
+
+    step_radius bounds a single sweep's move; k sweeps compose to at most
+    k*step_radius*(hi-lo). Pins BOTH directions: the k-sweep bound holds, and the
+    1-sweep bound does NOT (otherwise step_radius would be a global budget and the
+    number of sweeps would buy nothing).
+    """
+    torch.manual_seed(0)
+    step_radius = 0.1
+    k = 6
+    x0 = torch.full((32, DATA_DIM), 0.5)
+    purifier = GibbsPurification(
+        num_bins=NUM_BINS, gibbs_batch_size=32, step_radius=step_radius
+    )
+    purified, _ = purifier.purify(cbm, x0, n_sweeps=k, device="cpu")
+    lo, hi = cbm.input_range
+    delta = step_radius * (hi - lo)
+    drift = (purified - x0).abs().max()
+
+    assert drift <= k * delta + 1e-5, "drift exceeded the k-sweep envelope"
+    assert drift > delta + 1e-5, (
+        "drift never exceeded a single step — the window is not re-centring per "
+        "sweep, so n_sweeps is not acting as the strength knob"
+    )
+
 
 def test_restricted_purify_log_px_finite(cbm, x_adv):
-    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, radius=0.3)
+    purifier = GibbsPurification(num_bins=NUM_BINS, gibbs_batch_size=BATCH_SIZE, step_radius=0.3)
     _, log_px = purifier.purify(cbm, x_adv, n_sweeps=3, device="cpu")
     assert torch.isfinite(log_px).all()
 
@@ -151,8 +218,8 @@ def test_purify_snapshots_partial_batch_valid(cbm):
         assert (xp >= lo - 1e-5).all() and (xp <= hi + 1e-5).all()
 
 
-@pytest.mark.parametrize("radius", [None, 0.2])
-def test_gibbs_stable_when_amplitudes_overflow(radius):
+@pytest.mark.parametrize("step_radius", [None, 0.2])
+def test_gibbs_stable_when_amplitudes_overflow(step_radius):
     """Gibbs weights stay correct when the raw |ψ|² would overflow to inf.
 
     The sweep evaluates a full-chain contraction per candidate, so on a long
@@ -181,27 +248,33 @@ def test_gibbs_stable_when_amplitudes_overflow(radius):
 
     torch.manual_seed(0)
     x_adv = lo + (hi - lo) * torch.rand(6, data_dim)
-    purifier = GibbsPurification(num_bins=8, gibbs_batch_size=4, radius=radius)
+    # step_radius=None also keeps the global fixed-grid path under test.
+    purifier = GibbsPurification(num_bins=8, gibbs_batch_size=4, step_radius=step_radius)
     torch.manual_seed(1)
-    # n_sweeps=1 so the radius restriction (centred on the sweep-start snapshot)
-    # is well-defined relative to x_adv; across multiple sweeps x_cur may drift up
-    # to n_sweeps*radius from the original, so a single-radius bound wouldn't hold.
+    # n_sweeps=1 so the restriction (centred on the sweep-start snapshot) is
+    # well-defined relative to x_adv; across k sweeps x_cur may drift up to
+    # k*step_radius from the original, so a single-step bound would not hold.
     xp, lp = purifier.purify(cbm, x_adv, n_sweeps=1, device="cpu")
 
     assert xp.shape == x_adv.shape
     assert torch.isfinite(xp).all()
     assert (xp >= lo).all() and (xp <= hi).all()
     assert len(torch.unique(xp)) > 1, "sampler collapsed to a single bin"
-    if radius is not None:
-        assert (xp - x_adv).abs().max() <= radius * (hi - lo) + 1e-6
+    if step_radius is not None:
+        assert (xp - x_adv).abs().max() <= step_radius * (hi - lo) + 1e-6
 
 
 def test_gibbs_numeric_regression():
-    """Pin Gibbs output so future changes (e.g. the reset hoist) can't silently alter it.
+    """Pin Gibbs output so future changes can't silently alter it.
 
-    Golden values captured from the per-feature-reset implementation; reproduced exactly
-    by the current per-batch-reset code for both a batch size that divides n_samples and
-    one that leaves a partial final batch.
+    Checked for both a batch size that divides n_samples and one that leaves a partial
+    final batch.
+
+    Goldens re-pinned 2026-07-27 for the local-grid change: the restricted sweep now
+    discretizes each sample's own [x̄ ± delta] window with num_bins points instead of
+    masking a global linspace(lo, hi, num_bins) down to it. That intentionally changes
+    which values are reachable, so the previous goldens
+    ({3: (-4.5714287758, -10.9865303040), 4: (-2.0, -9.3423662186)}) no longer apply.
     """
     from src.model import ConditionalBornMachine, CBMConfig, MPSInitConfig
 
@@ -215,12 +288,12 @@ def test_gibbs_numeric_regression():
         m.prepare(device=torch.device("cpu")); m.eval(); m.cache_log_Z()
         return m
 
-    golden = {3: (-4.5714287758, -10.9865303040), 4: (-2.0000000000, -9.3423662186)}
+    golden = {3: (-0.4685872495, -13.2247095108), 4: (-2.3235769272, -13.2589607239)}
     for bs, (xp_sum, lp_sum) in golden.items():
         cbm = make_cbm()
         torch.manual_seed(123)
         x_adv = -1 + 2 * torch.rand(6, 4)
-        purifier = GibbsPurification(num_bins=8, gibbs_batch_size=bs, radius=0.2)
+        purifier = GibbsPurification(num_bins=8, gibbs_batch_size=bs, step_radius=0.2)
         torch.manual_seed(777)
         xp, lp = purifier.purify(cbm, x_adv, n_sweeps=2, device="cpu")
         assert xp.sum().item() == pytest.approx(xp_sum, abs=1e-5)

--- a/tests/unit/test_differential_sampling.py
+++ b/tests/unit/test_differential_sampling.py
@@ -121,3 +121,37 @@ def test_draw_from_grid_log_nan_handled(grid):
 def test_draw_from_grid_log_batch_size_1(grid):
     samples = draw_from_grid_log(torch.zeros(1, BINS), grid)
     assert samples.shape == (1,)
+
+
+# ---- draw_from_grid_log with a per-row grid ----
+# Restricted Gibbs builds a candidate window centred on each sample, so `z` is
+# (batch, bins) rather than a single shared grid.
+
+def test_draw_from_grid_log_batched_z():
+    """With a per-row grid, each sample must come from its OWN row's grid."""
+    # Disjoint per-row grids: row i spans [10i, 10i + 1].
+    z = torch.stack([torch.linspace(10.0 * i, 10.0 * i + 1.0, BINS) for i in range(BATCH)])
+    samples = draw_from_grid_log(torch.zeros(BATCH, BINS), z)
+    assert samples.shape == (BATCH,)
+    for i in range(BATCH):
+        assert samples[i] in z[i], f"row {i} sampled outside its own grid"
+
+
+def test_draw_from_grid_log_batched_z_respects_weights():
+    """A single finite bin per row is always selected, at that row's own value."""
+    z = torch.stack([torch.linspace(10.0 * i, 10.0 * i + 1.0, BINS) for i in range(BATCH)])
+    log_p = torch.full((BATCH, BINS), float("-inf"))
+    picks = torch.arange(BATCH) % BINS
+    log_p[torch.arange(BATCH), picks] = 0.0
+    samples = draw_from_grid_log(log_p, z)
+    assert torch.equal(samples, z[torch.arange(BATCH), picks])
+
+
+def test_draw_from_grid_log_batched_z_matches_1d(grid):
+    """A (batch, bins) grid whose rows are all the same 1-D grid is equivalent to it."""
+    log_p = torch.randn(BATCH, BINS)
+    torch.manual_seed(0)
+    one_d = draw_from_grid_log(log_p, grid)
+    torch.manual_seed(0)
+    batched = draw_from_grid_log(log_p, grid.unsqueeze(0).expand(BATCH, BINS).contiguous())
+    assert torch.equal(one_d, batched)


### PR DESCRIPTION
…nalysis script

Gibbs purification's restriction window already re-centred at the start of every sweep, so the k-sweep envelope was k*delta rather than a single global ball -- but the docstring claimed the opposite ("The same budget applies regardless of n_sweeps") and the parameter name `radius` reinforced the wrong reading. Rename to `step_radius`, document the real contract: a per-sweep L-inf move whose strength is set by n_sweeps alone, so the defense never has to be told the attacker's budget. Defaults stay 0.1 so existing sweep.py Gibbs numbers remain comparable.

Replace the global-grid-plus-mask candidate scheme with a per-sample local grid, linspace(x_bar_k +/- delta, num_bins) clamped to the input range. At the 0.05 step radius the new script uses, the window is 10% of the domain, so masking a global 96-bin grid left ~10 admissible bins and spent ~90% of every forward pass on candidates it then discarded. The local grid needs no mask (no bin can be inadmissible, no row can be all -inf) and gives full resolution inside the window. Trade-off, recorded in the docstring: the proposal support moves each sweep, so this is a local Metropolis-within-Gibbs move rather than exact Gibbs on one fixed discretization; step_radius=None remains the fixed-grid path.

draw_from_grid_log now accepts a (batch, num_bins) grid alongside the 1-D form.

New analysis/gibbs.py: standalone Gibbs-purification analysis for a seed sweep, split out because Gibbs costs orders of magnitude more than everything in sweep.py. Runs the same PGD strengths, purifies for k = 1, 3, 6 sweeps, and reports clean/adv/purified accuracy plus recovery. --n-eval is the cost knob (cost is linear in it); the subsample is fixed and seeded so it is shared across the clean row, every epsilon and every run, keeping all comparisons paired, and the resolved count is printed up front and written to every CSV row as gibbs_n_samples.

Numerical stability was already sound (log_amp_sq -> logsumexp -> row-max-subtract, marginal_log_probability for the final log p(x)); only a stale comment about re-tracing was corrected -- the accumulate path is eager and self-resets.

test_gibbs_numeric_regression goldens re-pinned for the local-grid change; the previous values are preserved in the test docstring as the pre-change baseline.

Validated on 3 freshly-trained moons/nat/legendre/d10r6 runs at --n-eval 1000: recovery rises monotonically with k (0.27 -> 0.46 at eps=0.3) for a ~7pt clean- accuracy cost by k=6, 17.5s per model. 321 tests pass.