### PR TITLE
AT: select on the objective (at_loss), not robust accuracy

### DIFF
--- a/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/chlorineconcentration/at/legendre/hpo.yaml
+++ b/configs/experiments/chlorineconcentration/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/circles/at/fourier/d10r6c64/hpo/a0.yaml
+++ b/configs/experiments/circles/at/fourier/d10r6c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/fourier/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/circles/at/fourier/d10r6c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/fourier/d30r18c64/hpo/a0.yaml
+++ b/configs/experiments/circles/at/fourier/d30r18c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/fourier/d30r18c64/seed_sweep/a0.yaml
+++ b/configs/experiments/circles/at/fourier/d30r18c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/legendre/d10r6c64/cls_reg.yaml
+++ b/configs/experiments/circles/at/legendre/d10r6c64/cls_reg.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 1            # placeholder; swept via hydra sweeper
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 100           # >= max max_epoch -> no early stopping during sweep
 
     evasion:

--- a/configs/experiments/circles/at/legendre/d10r6c64/hpo/a0.yaml
+++ b/configs/experiments/circles/at/legendre/d10r6c64/hpo/a0.yaml
@@ -46,7 +46,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/legendre/d10r6c64/hpo_linf.yaml
+++ b/configs/experiments/circles/at/legendre/d10r6c64/hpo_linf.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/legendre/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/circles/at/legendre/d10r6c64/seed_sweep/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/circles/at/legendre/d10r6c64/seed_sweep_linf.yaml
+++ b/configs/experiments/circles/at/legendre/d10r6c64/seed_sweep_linf.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketx/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketx/at/legendre/hpo.yaml
+++ b/configs/experiments/cricketx/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/crickety/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/crickety/at/legendre/hpo.yaml
+++ b/configs/experiments/crickety/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/cricketz/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/cricketz/at/legendre/hpo.yaml
+++ b/configs/experiments/cricketz/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/ecg200/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/hpo.yaml
+++ b/configs/experiments/ecg200/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/ecg200/at/legendre/hpo/clean_weight.yaml
+++ b/configs/experiments/ecg200/at/legendre/hpo/clean_weight.yaml
@@ -63,7 +63,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: null
     save: false

--- a/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/hpo.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/experiments/italypowerdemand/at/legendre/hpo/clean_weight.yaml
+++ b/configs/experiments/italypowerdemand/at/legendre/hpo/clean_weight.yaml
@@ -68,7 +68,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: null
     save: false

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/hpo/cw_split_a001.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/hpo/cw_split_a001.yaml
@@ -30,8 +30,8 @@
 # eval_rob_freq=5 is now the cadence of the WHOLE validation pass (gen_on_clean
 # routes validation through eval_split), not just of the robustness eval; there
 # is no clean-only eval in between. patience=10 is unchanged and still means 10
-# validation events (~50 epochs): with stop_crit="rob" the default path already
-# skipped non-rob epochs without counting them.
+# validation events (~50 epochs): the default path likewise only ever counted
+# attack epochs, since stop_crit="at_loss" is produced by the attack pass alone.
 #
 # Robustness is measured on a fixed (1-cw) fraction of the valid set, drawn once
 # from a constant seed. Its size is logged as n_rob_valid; note this makes
@@ -77,7 +77,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10             # validation events, i.e. ~50 epochs at eval_rob_freq=5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5         # cadence of the whole validation pass under the split
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: false

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/seed_sweep/a0.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/seed_sweep/a0.yaml
@@ -55,7 +55,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/seed_sweep/a001.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r10c64/seed_sweep/a001.yaml
@@ -78,7 +78,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/hpo/at.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/hpo/at.yaml
@@ -29,7 +29,7 @@ trainer:
   adversarial:
     max_epoch: 100
     batch_size: 512
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 10
     eval_rob_freq: 5
     acc_floor: 0.90   # only select epochs whose clean valid-acc stays >= 90%

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/hpo/cw_split_a001.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/hpo/cw_split_a001.yaml
@@ -30,8 +30,8 @@
 # eval_rob_freq=5 is now the cadence of the WHOLE validation pass (gen_on_clean
 # routes validation through eval_split), not just of the robustness eval; there
 # is no clean-only eval in between. patience=10 is unchanged and still means 10
-# validation events (~50 epochs): with stop_crit="rob" the default path already
-# skipped non-rob epochs without counting them.
+# validation events (~50 epochs): the default path likewise only ever counted
+# attack epochs, since stop_crit="at_loss" is produced by the attack pass alone.
 #
 # Robustness is measured on a fixed (1-cw) fraction of the valid set, drawn once
 # from a constant seed. Its size is logged as n_rob_valid; note this makes
@@ -77,7 +77,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10             # validation events, i.e. ~50 epochs at eval_rob_freq=5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5         # cadence of the whole validation pass under the split
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: false

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/a0.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/a0.yaml
@@ -54,7 +54,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/a001.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/a001.yaml
@@ -78,7 +78,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/at.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r20c64/seed_sweep/at.yaml
@@ -28,7 +28,7 @@ trainer:
   adversarial:
     max_epoch: 100
     batch_size: 512
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 10
     eval_rob_freq: 5
     acc_floor: 0.90   # only select epochs whose clean valid-acc stays >= 90%

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r40c64/seed_sweep/a0.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r40c64/seed_sweep/a0.yaml
@@ -54,7 +54,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/d3r40c64/seed_sweep/a001.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/d3r40c64/seed_sweep/a001.yaml
@@ -83,7 +83,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: true

--- a/configs/experiments/mnist_full_r12/at/legendre/hpo/clean_weight.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/hpo/clean_weight.yaml
@@ -79,7 +79,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: false

--- a/configs/experiments/mnist_full_r12/at/legendre/hpo/grid.yaml
+++ b/configs/experiments/mnist_full_r12/at/legendre/hpo/grid.yaml
@@ -71,7 +71,7 @@ trainer:
     max_epoch: 100
     batch_size: 512
     patience: 10
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     acc_floor: 0.90          # only select epochs whose clean valid-acc stays >= 90%
     save: false

--- a/configs/experiments/moons/at/fourier/d10r6c64/hpo/a0.yaml
+++ b/configs/experiments/moons/at/fourier/d10r6c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/fourier/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/moons/at/fourier/d10r6c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/fourier/d30r18c64/hpo/a0.yaml
+++ b/configs/experiments/moons/at/fourier/d30r18c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/fourier/d30r18c64/seed_sweep/a0.yaml
+++ b/configs/experiments/moons/at/fourier/d30r18c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/legendre/d10r6c64/cls_reg.yaml
+++ b/configs/experiments/moons/at/legendre/d10r6c64/cls_reg.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 1            # placeholder; swept via hydra sweeper
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 100           # >= max max_epoch -> no early stopping during sweep
 
     evasion:

--- a/configs/experiments/moons/at/legendre/d10r6c64/hpo/a0.yaml
+++ b/configs/experiments/moons/at/legendre/d10r6c64/hpo/a0.yaml
@@ -46,7 +46,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/legendre/d10r6c64/hpo_linf.yaml
+++ b/configs/experiments/moons/at/legendre/d10r6c64/hpo_linf.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/legendre/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/moons/at/legendre/d10r6c64/seed_sweep/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/moons/at/legendre/d10r6c64/seed_sweep_linf.yaml
+++ b/configs/experiments/moons/at/legendre/d10r6c64/seed_sweep_linf.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/spirals/at/fourier/d10r6c64/hpo/a0.yaml
+++ b/configs/experiments/spirals/at/fourier/d10r6c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/spirals/at/fourier/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/spirals/at/fourier/d10r6c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/spirals/at/fourier/d30r18c64/hpo/a0.yaml
+++ b/configs/experiments/spirals/at/fourier/d30r18c64/hpo/a0.yaml
@@ -45,7 +45,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/spirals/at/fourier/d30r18c64/seed_sweep/a0.yaml
+++ b/configs/experiments/spirals/at/fourier/d30r18c64/seed_sweep/a0.yaml
@@ -44,7 +44,7 @@ trainer:
   adversarial:
     max_epoch: 300
     batch_size: 256
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     patience: 300
 
     evasion:

--- a/configs/experiments/spirals/at/legendre/d10r6c64/seed_sweep/a0.yaml
+++ b/configs/experiments/spirals/at/legendre/d10r6c64/seed_sweep/a0.yaml
@@ -74,7 +74,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/d10r6c64/seed_sweep/a0001.yaml
+++ b/configs/experiments/spirals/at/legendre/d10r6c64/seed_sweep/a0001.yaml
@@ -75,7 +75,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/d4r3c64/seed_sweep/a0.yaml
+++ b/configs/experiments/spirals/at/legendre/d4r3c64/seed_sweep/a0.yaml
@@ -74,7 +74,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/d4r3c64/seed_sweep/a0001.yaml
+++ b/configs/experiments/spirals/at/legendre/d4r3c64/seed_sweep/a0001.yaml
@@ -75,7 +75,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/d6r4c64/seed_sweep/a0.yaml
+++ b/configs/experiments/spirals/at/legendre/d6r4c64/seed_sweep/a0.yaml
@@ -74,7 +74,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/d6r4c64/seed_sweep/a0001.yaml
+++ b/configs/experiments/spirals/at/legendre/d6r4c64/seed_sweep/a0001.yaml
@@ -75,7 +75,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null
     save: true
 

--- a/configs/experiments/spirals/at/legendre/hpo/at.yaml
+++ b/configs/experiments/spirals/at/legendre/hpo/at.yaml
@@ -81,7 +81,7 @@ trainer:
     batch_size: 256
     patience: 20                  # validation events, NOT epochs (= 100 epochs)
     eval_rob_freq: 5
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     acc_floor: null               # no clean-accuracy floor on the 2-D toys
     save: false
 
@@ -122,7 +122,7 @@ hydra:
       _target_: optuna.samplers.TPESampler
       seed: 42
       n_startup_trials: 8
-    direction: maximize           # rob
+    direction: minimize           # at_loss (a loss; train.py does not negate it)
     n_trials: 20
     n_jobs: 1
     params:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a0.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a001.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a01.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a02.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r100c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 64
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a0.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a001.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a01.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a02.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r10c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a0.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a001.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a01.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a02.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r20c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a0.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a001.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a01.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a02.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r40c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a0.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a0.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a001.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a001.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a01.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a01.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a02.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/d3r60c64/seed_sweep_a02.yaml
@@ -37,7 +37,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: true
     norm_control:

--- a/configs/experiments/syntheticcontrol/at/legendre/hpo.yaml
+++ b/configs/experiments/syntheticcontrol/at/legendre/hpo.yaml
@@ -50,7 +50,7 @@ trainer:
     max_epoch: 800
     batch_size: 100
     patience: 200
-    stop_crit: "rob"
+    stop_crit: "at_loss"
     eval_rob_freq: 5
     save: false
     norm_control:

--- a/configs/trainer/adversarial/pgd_at.yaml
+++ b/configs/trainer/adversarial/pgd_at.yaml
@@ -22,7 +22,11 @@ evasion:
   step_size: null  # defaults to 2.5 * eps_abs / num_steps
   random_start: true
 
-stop_crit: "rob"
+# Select on the objective mirrored on valid: (1-cw)*mixed_nll(x_adv) + cw*mixed_nll(x)
+# under the default objective, or the split formula under gen_on_clean. Unlike "rob"
+# it sees the generative half of the loss at alpha>0. Produced by the attack pass
+# only, so it requires eval_rob_freq >= 1; robustness is still evaluated and logged.
+stop_crit: "at_loss"
 patience: 30
 
 eval_rob_freq: 5

--- a/configs/trainer/adversarial/test.yaml
+++ b/configs/trainer/adversarial/test.yaml
@@ -22,7 +22,7 @@ evasion:
   step_size: null
   random_start: true
 
-stop_crit: "rob"
+stop_crit: "at_loss"
 patience: 5
 
 eval_rob_freq: 1

--- a/src/train/adversarial.py
+++ b/src/train/adversarial.py
@@ -12,8 +12,8 @@ from src.utils.train import (
     NormControlConfig,
     NormRegularizer,
     NormTracker,
+    eval_at,
     eval_metrics,
-    eval_rob,
     eval_split,
     optimizer,
     resolve_log_target,
@@ -41,13 +41,21 @@ class AdversarialConfig:
     runs *every* ``eval_rob_freq`` epochs and nothing in between. ``patience`` is
     then counted in validation events, not epochs: ``eval_rob_freq=5`` with
     ``patience=200`` means 1000 epochs without improvement.
+
+    ``stop_crit="at_loss"`` (the default) selects on the validation mirror of
+    whichever of the two objectives above the run is training under — computed by
+    :func:`eval_at` or :func:`eval_split` respectively. It is the only criterion
+    that sees the generative half of the loss at ``alpha > 0``; ``rob`` selects on
+    robust accuracy alone, and ``mixed_loss`` on clean data alone. Like ``rob`` it
+    is produced only on ``eval_rob_freq`` epochs, so it requires
+    ``eval_rob_freq >= 1``.
     """
     max_epoch: int = 100
     batch_size: int = 64
     alpha: float = 0.0  # mixed-NLL weight for the training objective: alpha*gen + (1-alpha)*dis
     optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
     evasion: EvasionConfig = field(default_factory=EvasionConfig)
-    stop_crit: str = "acc"
+    stop_crit: str = "at_loss"
     patience: int = 250
     eval_rob_freq: int = 5
     clean_weight: float = 0.0
@@ -66,9 +74,9 @@ class AdversarialConfig:
 import logging
 logger = logging.getLogger(__name__)
 
-_LOSS_METRICS = {"dis_loss", "gen_loss", "mixed_loss"}
+_LOSS_METRICS = {"dis_loss", "gen_loss", "mixed_loss", "at_loss"}
 _ACC_METRICS = {"acc", "rob"}
-_VALID_STOP_CRIT = {"dis_loss", "gen_loss", "mixed_loss", "acc", "rob"}
+_VALID_STOP_CRIT = _LOSS_METRICS | _ACC_METRICS
 
 # Constant (not the run seed) so every seed in a sweep evaluates robustness on
 # the same validation samples, keeping cross-seed rob comparisons clean.
@@ -175,7 +183,8 @@ class AdversarialTrainer:
         )
         # Robustness is logged under its relative budget so the key states what was
         # measured. The Optuna objective does NOT go through this key — it flows
-        # through trainer.best[stop_crit] <- valid_perf["rob"] <- eval_rob().
+        # through trainer.best[stop_crit] <- valid_perf, whose adversarial entries
+        # ("rob", "at_loss") come from eval_at() / eval_split().
         self.rob_metric_key = f"rob/valid/{fmt_budget(self.base_eps_rel)}"
         logger.info(
             f"Attack budget: eps_rel={self.base_eps_rel:g} "
@@ -190,11 +199,18 @@ class AdversarialTrainer:
         }
         if self.train_cfg.eval_rob_freq > 0:
             self.best["rob"] = 0.0
+            self.best["at_loss"] = float("inf")
         self.stopping_criterion_name = self.train_cfg.stop_crit
         if self.stopping_criterion_name not in _VALID_STOP_CRIT:
             raise ValueError(
                 f"Invalid stop_crit '{self.stopping_criterion_name}'. "
                 f"Must be one of: {sorted(_VALID_STOP_CRIT)}"
+            )
+        if self.stopping_criterion_name == "at_loss" and self.train_cfg.eval_rob_freq < 1:
+            raise ValueError(
+                "stop_crit='at_loss' requires eval_rob_freq >= 1: the criterion is "
+                "the objective mirrored on the validation attack, so with no "
+                "attack epochs it is never produced and no model is ever selected."
             )
 
     def _get_eps_abs(self, epoch: int) -> float:
@@ -403,6 +419,16 @@ class AdversarialTrainer:
                 )
                 # Kept out of valid_perf so it never leaks into `best`.
                 self._n_rob_valid = self.valid_perf.pop("n_rob")
+            elif do_valid and rob_freq and (self.epoch % rob_freq == 0):
+                # One pass covering clean metrics, the attack, and the objective
+                # mirrored on valid — cheaper than eval_metrics + eval_rob, which
+                # forwarded the clean batch twice.
+                self.valid_perf = eval_at(
+                    self.cbm, self.datahandler.classification["valid"],
+                    self.attack, self.base_eps_abs, self.device,
+                    alpha=self.train_cfg.alpha,
+                    clean_weight=self.train_cfg.clean_weight,
+                )
             elif do_valid:
                 dis_loss, acc, gen_loss = eval_metrics(
                     self.cbm, self.datahandler.classification["valid"], self.device
@@ -413,13 +439,6 @@ class AdversarialTrainer:
                     "dis_loss": dis_loss, "gen_loss": gen_loss,
                     "mixed_loss": mixed_loss, "acc": acc,
                 }
-
-                if rob_freq and (self.epoch % rob_freq == 0):
-                    rob = eval_rob(
-                        self.cbm, self.datahandler.classification["valid"],
-                        self.attack, self.base_eps_abs, self.device
-                    )
-                    self.valid_perf["rob"] = rob
 
             postfix = {"loss": f"{self._train_loss:.4f}"}
             if do_valid:
@@ -446,6 +465,10 @@ class AdversarialTrainer:
                         "mixed_loss/valid": self.valid_perf["mixed_loss"],
                         "acc/valid":        self.valid_perf["acc"],
                     })
+                    if "at_loss" in self.valid_perf:
+                        # The objective mirrored on valid — the selection criterion
+                        # under stop_crit="at_loss". Only produced on attack epochs.
+                        metrics["at_loss/valid"] = self.valid_perf["at_loss"]
                     if "rob" in self.valid_perf:
                         # Keyed by the run's relative budget. Robustness is always
                         # evaluated at base_eps_abs (the curriculum's endpoint), so

--- a/src/utils/train.py
+++ b/src/utils/train.py
@@ -346,6 +346,19 @@ def eval_metrics(cbm, loader, device, progress: bool = False) -> tuple[float, fl
     return dis_loss, acc, gen_loss
 
 
+def _mix(dis: float, gen: float, alpha: float) -> float:
+    """``(1-α)·dis + α·gen``, gated exactly as in :meth:`CBM.mixed_nll`.
+
+    Each term is dropped rather than multiplied by a zero weight, so an endpoint
+    alpha never turns a non-finite half (a nan ``gen`` from a diverged ``log_Z``)
+    into a nan mix.
+    """
+    out = (1.0 - alpha) * dis if alpha < 1.0 else 0.0
+    if alpha > 0.0:
+        out += alpha * gen
+    return out
+
+
 def eval_split(
     cbm, loader, attack, eps_abs: float, device, *,
     alpha: float, clean_weight: float, adv_indices, progress: bool = False,
@@ -354,9 +367,9 @@ def eval_split(
 
     Mirrors the ``gen_on_clean`` training objective on the validation set:
 
-        mixed_loss = (1-α)·[ (1-cw)·mean_{S_adv} L_dis(x_adv)
-                           +    cw ·mean_{S_cln} L_dis(x)     ]
-                   +   α ·mean_{all} L_gen(x)
+        at_loss = (1-α)·[ (1-cw)·mean_{S_adv} L_dis(x_adv)
+                        +    cw ·mean_{S_cln} L_dis(x)     ]
+                +   α ·mean_{all} L_gen(x)
 
     ``S_adv`` is the fixed sample subset given by ``adv_indices`` (positions in the
     loader's iteration order — non-train splits are built with ``shuffle=False``,
@@ -365,9 +378,11 @@ def eval_split(
     over the validation set while attacking only a ``(1-cw)`` fraction of it.
 
     ``dis_loss``/``gen_loss``/``acc`` are clean and over the *full* set, so they
-    stay directly comparable to :func:`eval_metrics`. ``rob`` is over ``S_adv``
-    only, and is omitted when that subset is empty (``clean_weight == 1``);
-    ``n_rob`` reports its size so the estimator is recoverable from the run.
+    stay directly comparable to :func:`eval_metrics`, and so is ``mixed_loss``,
+    their clean α-mix — ``at_loss`` is the only key that sees adversarial data.
+    ``rob`` is over ``S_adv`` only, and is omitted when that subset is empty
+    (``clean_weight == 1``); ``n_rob`` reports its size so the estimator is
+    recoverable from the run.
     """
     cbm.eval()
     with torch.no_grad():
@@ -437,22 +452,109 @@ def eval_split(
     if n_cln:
         dis_term += clean_weight * _mean(dis_cln_sum, n_cln)
 
-    # Terms are gated exactly as in CBM.mixed_nll, so an endpoint alpha never
-    # multiplies a nan by zero.
-    mixed_loss = (1.0 - alpha) * dis_term if alpha < 1.0 else 0.0
-    if alpha > 0.0:
-        mixed_loss += alpha * gen_loss
-
     out = {
         "dis_loss": dis_loss,
         "gen_loss": gen_loss,
         "acc": _mean(correct, total),
-        "mixed_loss": mixed_loss,
+        "mixed_loss": _mix(dis_loss, gen_loss, alpha),
+        "at_loss": _mix(dis_term, gen_loss, alpha),
         "n_rob": n_adv,
     }
     if n_adv:
         out["rob"] = rob_correct / n_adv
     return out
+
+
+def eval_at(
+    cbm, loader, attack, eps_abs: float, device, *,
+    alpha: float, clean_weight: float, progress: bool = False,
+) -> dict:
+    """Combined clean + robust validation for the default adversarial objective.
+
+    The non-split counterpart of :func:`eval_split`: it mirrors
+
+        at_loss = (1-cw)·mixed_nll(x_adv, α) + cw·mixed_nll(x, α)
+
+    on the validation set, where ``mixed_nll(·, α) = (1-α)·L_dis + α·L_gen``. Both
+    terms are over the *whole* set — attacking a subset is the split path's device,
+    and is what makes its ``rob`` a subset estimator; here ``rob`` keeps exactly the
+    meaning it has in :func:`eval_rob`.
+
+    Note the generative half of the adversarial term is ``L_gen(x_adv)``, not
+    ``L_gen(x)``: this is a mirror of the objective actually minimized, and the
+    default objective does put the generative term on adversarial examples. (The
+    ``gen_on_clean`` objective does not — that is what ``eval_split`` is for.)
+
+    ``dis_loss``/``gen_loss``/``acc``/``mixed_loss`` are clean, so they stay directly
+    comparable to :func:`eval_metrics`; ``at_loss`` is the only key that sees
+    adversarial data. Cost is one clean forward plus one attack over the loader,
+    i.e. an ``eval_metrics`` and an ``eval_rob`` folded into a single pass.
+    """
+    cbm.eval()
+    with torch.no_grad():
+        log_Z = cbm.log_partition_function()
+    gen_finite = math.isfinite(log_Z.item())
+    if not gen_finite:
+        logger.warning(f"log_Z is non-finite ({log_Z.item()}); gen_loss will be nan.")
+
+    dis_sum = gen_sum = 0.0              # clean
+    dis_adv_sum = gen_adv_sum = 0.0      # adversarial
+    correct = rob_correct = total = 0
+
+    for data, labels in tqdm(
+        loader, desc=f"eval at eps_abs={eps_abs:.3g}", unit="batch", leave=False,
+        dynamic_ncols=True, disable=not progress,
+    ):
+        data, labels = data.to(device), labels.to(device)
+        B = len(labels)
+
+        with torch.no_grad():
+            # Same log|ψ|² entry point as eval_metrics / the loss: dispatches on
+            # cbm.accumulate, so validation matches training's numerics.
+            las = cbm._log_amp_sq(data)                       # (B, C)
+            log_sq_obs = las[range(B), labels]
+            dis_sum += (torch.logsumexp(las, dim=1) - log_sq_obs).sum().item()
+            correct += (las.argmax(dim=1) == labels).sum().item()
+            total += B
+            if gen_finite:
+                gen_sum += (log_Z - log_sq_obs).sum().item()
+
+        adv = attack.generate(born=cbm, naturals=data, labels=labels,
+                              eps_abs=eps_abs, device=device)
+        with torch.no_grad():
+            las_adv = cbm._log_amp_sq(adv)
+            log_sq_adv = las_adv[range(B), labels]
+            dis_adv_sum += (torch.logsumexp(las_adv, dim=1) - log_sq_adv).sum().item()
+            rob_correct += (las_adv.argmax(dim=1) == labels).sum().item()
+            if gen_finite:
+                gen_adv_sum += (log_Z - log_sq_adv).sum().item()
+
+    def _mean(s, n):
+        return s / n if n else float("nan")
+
+    dis_loss = _mean(dis_sum, total)
+    gen_loss = _mean(gen_sum, total) if gen_finite else float("nan")
+    mixed_loss = _mix(dis_loss, gen_loss, alpha)
+    mixed_adv = _mix(
+        _mean(dis_adv_sum, total),
+        _mean(gen_adv_sum, total) if gen_finite else float("nan"),
+        alpha,
+    )
+
+    # Gated like the training objective: at cw=0 the clean term is absent, not
+    # weighted by zero, so a nan clean half cannot leak into the criterion.
+    at_loss = (1.0 - clean_weight) * mixed_adv if clean_weight < 1.0 else 0.0
+    if clean_weight > 0.0:
+        at_loss += clean_weight * mixed_loss
+
+    return {
+        "dis_loss": dis_loss,
+        "gen_loss": gen_loss,
+        "acc": _mean(correct, total),
+        "mixed_loss": mixed_loss,
+        "at_loss": at_loss,
+        "rob": _mean(rob_correct, total),
+    }
 
 
 def eval_rob(cbm, loader, attack, eps_abs: float, device, progress: bool = False) -> float:

--- a/tests/integration/test_adversarial.py
+++ b/tests/integration/test_adversarial.py
@@ -4,6 +4,8 @@ Covers the `gen_on_clean` split objective against a real ConditionalBornMachine,
 real PGD attacks and a real DataHandler — the unit tests stub all three.
 """
 
+import math
+
 import pytest
 import torch
 
@@ -84,12 +86,34 @@ def test_split_run_completes_and_selects_a_model(dh):
     assert all(torch.isfinite(t).all() for t in cbm.tensors)
 
 
+@pytest.mark.parametrize("gen_on_clean", [False, True])
+def test_at_loss_selection_runs_end_to_end(dh, gen_on_clean):
+    """stop_crit='at_loss' selects a checkpoint under both objectives."""
+    cbm = _cbm()
+    cfg = _cfg(stop_crit="at_loss", gen_on_clean=gen_on_clean, alpha=0.5,
+               clean_weight=0.3, max_epoch=6, eval_rob_freq=2)
+    trainer = AdversarialTrainer(cbm=cbm, train_cfg=cfg, datahandler=dh,
+                                 device=torch.device("cpu"))
+
+    logged = []
+    trainer.train(on_epoch_end=lambda ep, m: logged.append((ep, m)))
+
+    # at_loss needs the attack pass, so it lands on eval_rob_freq epochs only.
+    assert [ep for ep, m in logged if "at_loss/valid" in m] == [2, 4, 6]
+    assert math.isfinite(trainer.best["at_loss"])
+    assert trainer.best["at_loss"] < float("inf")   # a model was actually selected
+    assert trainer.best_epoch in (2, 4, 6)
+    # Robustness is still evaluated and logged, it just no longer drives selection.
+    assert [ep for ep, m in logged if trainer.rob_metric_key in m] == [2, 4, 6]
+    assert all(torch.isfinite(t).all() for t in cbm.tensors)
+
+
 def test_split_and_unsplit_agree_at_alpha_zero(dh):
     """At alpha=0 the split is a no-op: same loss, bit-identical model after an epoch.
 
     Compared over a single epoch on purpose. The two modes run different
-    validation code (eval_split over a (1-cw) subset vs. eval_metrics + eval_rob
-    over the full set), which consumes different amounts of global RNG and so
+    validation code (eval_split over a (1-cw) subset vs. eval_at over the full
+    set), which consumes different amounts of global RNG and so
     reshuffles the *next* epoch's training batches differently — a divergence
     that says nothing about the objective. random_start=False likewise keeps the
     attack itself deterministic.

--- a/tests/unit/test_adversarial.py
+++ b/tests/unit/test_adversarial.py
@@ -13,7 +13,8 @@ from torch.utils.data import DataLoader, TensorDataset
 from src.train.adversarial import AdversarialTrainer, AdversarialConfig
 from src.model import ConditionalBornMachine, CBMConfig, MPSInitConfig
 from src.utils.train import (
-    NormControlConfig, NormRegularizer, NormTracker, eval_metrics, eval_split,
+    NormControlConfig, NormRegularizer, NormTracker, eval_at, eval_metrics,
+    eval_rob, eval_split,
 )
 
 
@@ -475,8 +476,8 @@ def test_eval_split_rob_absent_when_no_samples_attacked():
     assert out["n_rob"] == 0
 
 
-def test_eval_split_mixed_loss_matches_hand_computed_reference():
-    """mixed_loss reproduces the training objective, sample by sample."""
+def test_eval_split_at_loss_matches_hand_computed_reference():
+    """at_loss reproduces the split training objective, sample by sample."""
     device = torch.device("cpu")
     cbm = _tiny_cbm()
     cbm.prepare(device=device)
@@ -508,7 +509,148 @@ def test_eval_split_mixed_loss_matches_hand_computed_reference():
         (1 - cw) * sum(dis_adv) / len(dis_adv) + cw * sum(dis_cln) / len(dis_cln)
     ) + alpha * gen_all
 
-    assert abs(out["mixed_loss"] - ref) < 1e-4
+    assert abs(out["at_loss"] - ref) < 1e-4
+    # mixed_loss is the CLEAN alpha-mix, not the objective: it never sees x_adv,
+    # so it stays comparable to a NAT run's mixed_loss/valid.
+    clean_ref = (1 - alpha) * out["dis_loss"] + alpha * out["gen_loss"]
+    assert abs(out["mixed_loss"] - clean_ref) < 1e-9
+    assert abs(out["mixed_loss"] - out["at_loss"]) > 1e-6
+
+
+# ── default objective: combined validation (eval_at) ────────────────────────
+
+def test_eval_at_clean_metrics_match_eval_metrics():
+    """acc/dis_loss/gen_loss are clean and over the full set, as in eval_metrics."""
+    cbm = _tiny_cbm()
+    cbm.prepare(device=torch.device("cpu"))
+    # Evenly-dividing batches: eval_metrics averages per-batch means while eval_at
+    # averages per sample, so the two coincide exactly only at equal batch sizes.
+    loader = _valid_loader(n=20, batch_size=5)
+
+    out = eval_at(cbm, loader, _ShiftAttack(), 0.1, torch.device("cpu"),
+                  alpha=0.5, clean_weight=0.3)
+    dis_loss, acc, gen_loss = eval_metrics(cbm, loader, torch.device("cpu"))
+
+    assert abs(out["acc"] - acc) < 1e-9
+    assert abs(out["dis_loss"] - dis_loss) < 1e-5
+    assert abs(out["gen_loss"] - gen_loss) < 1e-5
+
+
+def test_eval_at_rob_matches_eval_rob_over_the_full_set():
+    """rob keeps eval_rob's meaning: every sample attacked, no subset estimator."""
+    device = torch.device("cpu")
+    cbm = _tiny_cbm()
+    cbm.prepare(device=device)
+    loader = _valid_loader(n=20, batch_size=6)
+    attack = _ShiftAttack()
+
+    out = eval_at(cbm, loader, attack, 0.1, device, alpha=0.5, clean_weight=0.3)
+    ref = eval_rob(cbm, loader, _ShiftAttack(), 0.1, device)
+
+    assert abs(out["rob"] - ref) < 1e-9
+    assert torch.cat(attack.seen).shape[0] == 20   # whole set, once each
+
+
+def test_eval_at_at_loss_matches_hand_computed_reference():
+    """at_loss reproduces (1-cw)*mixed_nll(x_adv) + cw*mixed_nll(x), sample by sample."""
+    device = torch.device("cpu")
+    cbm = _tiny_cbm()
+    cbm.prepare(device=device)
+    loader = _valid_loader(n=20, batch_size=6)
+    alpha, cw, shift = 0.5, 0.3, 0.05
+
+    out = eval_at(cbm, loader, _ShiftAttack(shift), 0.1, device,
+                  alpha=alpha, clean_weight=cw)
+
+    # Reference: one sample at a time, no batching.
+    xs = torch.cat([x for x, _ in loader])
+    ys = torch.cat([y for _, y in loader])
+    with torch.no_grad():
+        log_Z = cbm.log_partition_function()
+
+    def _terms(x, y):
+        with torch.no_grad():
+            las = cbm._log_amp_sq(x.unsqueeze(0))
+        return ((torch.logsumexp(las, dim=1) - las[0, y]).item(),
+                (log_Z - las[0, y]).item())
+
+    def _mixed(shifted):
+        pairs = [_terms(xs[i] + shifted, ys[i]) for i in range(len(ys))]
+        dis = sum(d for d, _ in pairs) / len(pairs)
+        gen = sum(g for _, g in pairs) / len(pairs)
+        return (1 - alpha) * dis + alpha * gen
+
+    # The generative half of the adversarial term is L_gen(x_adv), not L_gen(x):
+    # this mirrors the objective, which puts the whole mixed NLL on x_adv.
+    ref = (1 - cw) * _mixed(shift) + cw * _mixed(0.0)
+
+    assert abs(out["at_loss"] - ref) < 1e-4
+
+
+def test_eval_at_reduces_to_adversarial_dis_loss_at_alpha0_cw0():
+    """The anchor case: pure PGD-AT selects on the discriminative loss on x_adv."""
+    device = torch.device("cpu")
+    cbm = _tiny_cbm()
+    cbm.prepare(device=device)
+    loader = _valid_loader(n=20, batch_size=5)
+    shift = 0.05
+
+    out = eval_at(cbm, loader, _ShiftAttack(shift), 0.1, device,
+                  alpha=0.0, clean_weight=0.0)
+
+    # Same loader, shifted once up front: eval_at's adversarial dis term.
+    xs = torch.cat([x for x, _ in loader]) + shift
+    ys = torch.cat([y for _, y in loader])
+    shifted = DataLoader(TensorDataset(xs, ys), batch_size=5, shuffle=False)
+    ref_dis, _, _ = eval_metrics(cbm, shifted, device)
+
+    assert abs(out["at_loss"] - ref_dis) < 1e-5
+
+
+def test_eval_at_reduces_to_clean_mixed_loss_at_cw1():
+    """clean_weight=1 => no adversarial signal in the criterion."""
+    device = torch.device("cpu")
+    cbm = _tiny_cbm()
+    cbm.prepare(device=device)
+
+    out = eval_at(cbm, _valid_loader(), _ShiftAttack(), 0.1, device,
+                  alpha=0.5, clean_weight=1.0)
+
+    assert abs(out["at_loss"] - out["mixed_loss"]) < 1e-9
+    # rob is still measured and reported at cw=1 -- selection stops using the
+    # attack, evaluation does not.
+    assert math.isfinite(out["rob"])
+
+
+# ── at_loss as a stopping criterion ─────────────────────────────────────────
+
+def test_at_loss_is_minimized_not_maximized(cbm):
+    """at_loss is a loss: lower wins. Guards against an acc-style comparison."""
+    t = _make_trainer(cbm, stop_crit="at_loss")
+    t.best["at_loss"] = 0.5
+
+    t.valid_perf = {"acc": 0.9, "at_loss": 0.7}
+    t._update()
+    assert t.best["at_loss"] == 0.5          # worse (higher) => rejected
+    assert t.patience_counter == 1
+
+    t.valid_perf = {"acc": 0.9, "at_loss": 0.3}
+    t._update()
+    assert t.best["at_loss"] == 0.3          # better (lower) => selected
+    assert t.patience_counter == 0
+
+
+def test_at_loss_requires_positive_eval_rob_freq():
+    """at_loss comes from the attack pass, so eval_rob_freq=0 never produces it."""
+    import pytest
+    cfg = AdversarialConfig(
+        stop_crit="at_loss", eval_rob_freq=0,
+        norm_control=NormControlConfig(hard_every=0, soft_strength=0.0),
+    )
+    with pytest.raises(ValueError, match="eval_rob_freq >= 1"):
+        AdversarialTrainer(cbm=_tiny_cbm(), train_cfg=cfg,
+                           datahandler=_FakeDataHandler(n=20, batch_size=5),
+                           device=torch.device("cpu"))
 
 
 # ── gen_on_clean: validation cadence and patience accounting ────────────────
@@ -585,3 +727,7 @@ def test_unsplit_still_validates_every_epoch():
     assert [ep for ep, m in logged if "acc/valid" in m] == [1, 2, 3, 4]
     assert [ep for ep, m in logged if t.rob_metric_key in m] == [2, 4]
     assert not any("n_rob_valid" in m for _, m in logged)
+    # at_loss needs the attack, so it appears on rob epochs only; mixed_loss is
+    # clean and therefore emitted every epoch.
+    assert [ep for ep, m in logged if "at_loss/valid" in m] == [2, 4]
+    assert [ep for ep, m in logged if "mixed_loss/valid" in m] == [1, 2, 3, 4]

--- a/tests/unit/test_experiment_configs.py
+++ b/tests/unit/test_experiment_configs.py
@@ -101,7 +101,11 @@ def test_phase2_seed_sweep_is_uniform(name):
     if is_at:
         t = adv
         assert nll is None, f"{name}: AT config must not carry an nll node"
-        assert t.stop_crit == "rob", f"{name}: AT selects on rob"
+        assert t.stop_crit == "at_loss", (
+            f"{name}: every AT arm selects on at_loss (Phase 2, issue B) -- the "
+            f"training objective mirrored on valid, so the generative half of the "
+            f"loss enters selection at alpha>0 as robust accuracy never did"
+        )
         assert t.gen_on_clean is True, f"{name}: split objective is on for both AT alphas"
         # gen_on_clean raises at alpha=1; the AT arm must stay away from it.
         assert t.alpha < 1.0, f"{name}: gen_on_clean=True is invalid at alpha=1"
@@ -139,11 +143,14 @@ def test_phase2_hpo_search_space_is_identical(name):
     assert params[lr_key] == "tag(log, interval(1e-6, 1e-1))", (
         f"{name}: the lr search space must be the same for every alpha and arch"
     )
+    # Both arms now select on a loss, and experiments/train.py only negates the
+    # objective for acc/rob -- so "minimize" is the correct direction everywhere.
+    # This previously read "maximize" on the AT arm alongside stop_crit="rob",
+    # which maximized -rob, i.e. selected the LEAST robust trial.
+    assert cfg.hydra.sweeper.direction == "minimize"
     if "/at/" in name:
-        assert cfg.hydra.sweeper.direction == "maximize"   # rob
         assert params["trainer.adversarial.clean_weight"] == "interval(0.0, 0.5)"
     else:
-        assert cfg.hydra.sweeper.direction == "minimize"   # mixed_loss
         assert len(params) == 1, f"{name}: NAT HPO sweeps lr only"
 
 

--- a/tools/fill_hpo.py
+++ b/tools/fill_hpo.py
@@ -116,6 +116,10 @@ def get_metric_info(hpo_cfg: Dict, trainer: str) -> Tuple[str, bool]:
         return "gen_loss/valid", True
     elif stop_crit == "mixed_loss":
         return "mixed_loss/valid", True
+    elif stop_crit == "at_loss":
+        # AT only: the training objective mirrored on valid. Logged every
+        # eval_rob_freq epochs, unlike the clean losses above.
+        return "at_loss/valid", True
     elif stop_crit == "acc":
         return "acc/valid", False
     elif stop_crit == "rob":


### PR DESCRIPTION
Every AT config selected checkpoints on stop_crit="rob" while the objective actually minimized is a loss. Defensible at alpha=0, where the objective is purely discriminative; wrong at alpha>0, where the generative half of the loss never entered selection at all. This is the AT counterpart of the NAT unification on mixed_loss, and it matters now that the Phase 2/3 AT ladder runs at alpha>0.

New criterion at_loss = the training objective mirrored on the validation set:

    gen_on_clean=false:  (1-cw)*mixed_nll(x_adv, a) + cw*mixed_nll(x, a)
    gen_on_clean=true:   (1-a)*[(1-cw)*L_dis(x_adv) + cw*L_dis(x)] + a*L_gen(x)

The quantity did not exist in the default path -- validation computed mixed_loss on clean data only and eval_rob returned a bare accuracy -- so add eval_at, the non-split counterpart of eval_split: one pass over valid covering the clean metrics, the full-set attack, and the mirror. It replaces eval_metrics + eval_rob on attack epochs and is cheaper than both, which forwarded the clean batch twice. Robustness is still evaluated and logged under rob/valid/{eps_rel}; it just no longer drives selection.

eval_split's objective is renamed from mixed_loss to at_loss and it now returns a genuine clean mixed_loss, so mixed_loss is uniformly the clean alpha-mix in both AT paths and stays comparable NAT <-> AT.

at_loss is produced by the attack pass, so stop_crit="at_loss" with eval_rob_freq=0 raises rather than silently never selecting a model.

Also fixes an inverted HPO objective: spirals/at/legendre/hpo/at.yaml said direction: maximize alongside stop_crit="rob", but experiments/train.py negates the objective for acc/rob -- so it maximized -rob, i.e. would have selected the LEAST robust trial. test_experiment_configs asserted that "maximize", pinning the bug rather than catching it. Both arms now select on a loss, so minimize is correct everywhere. Phase 3 spirals AT has not run; nothing published is affected.

192 configs switched (190 AT experiments + both base trainer YAMLs), plus the AdversarialConfig default. AT sweeps run before this commit selected on rob and are not strictly comparable to post-unification ones.

761 tests pass (was 752): hand-computed at_loss references in both modes, the alpha=0/cw=0 anchor (at_loss == adversarial dis_loss), the cw=1 clean limit, rob still matching eval_rob over the full set, minimize-direction selection, the eval_rob_freq guard, and end-to-end runs under both objectives.